### PR TITLE
Fix chatty logs

### DIFF
--- a/azureeyemodule/app/model/azureeyemodel.cpp
+++ b/azureeyemodule/app/model/azureeyemodel.cpp
@@ -22,7 +22,7 @@
 namespace model {
 
 AzureEyeModel::AzureEyeModel(const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution, bool show)
-    : modelfiles(modelfpaths), mvcmd(mvcmd), videofile(videofile), resolution(resolution), show_output(show)
+    : modelfiles(modelfpaths), mvcmd(mvcmd), videofile(videofile), resolution(resolution), show_output(show), inference_logger({})
 {
     // Nothing to do
 }
@@ -61,6 +61,11 @@ void AzureEyeModel::wait_for_device()
     {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
+}
+
+void AzureEyeModel::log_inference(const std::string &msg)
+{
+    this->inference_logger.log_info(msg);
 }
 
 void AzureEyeModel::save_retraining_data(const cv::Mat &bgr, const std::vector<float> &confidences)
@@ -267,7 +272,7 @@ bool AzureEyeModel::unzip_model(const std::string &zippath, std::string &labelfi
     }
     else
     {
-        util::log_error("no config.json, cvexport.manifest, or model.blob file found in the zip archive.");
+        util::log_error("No config.json, cvexport.manifest, or model.blob file found in the zip archive.");
         return false;
     }
 
@@ -370,7 +375,7 @@ bool AzureEyeModel::load_manifest(const std::string &manifestfpath, std::vector<
     int ret = util::run_command("python3 /app/update_cvs_openvino.py /app/model/model.xml /app/model/model.bin /app/model/out.bin && mv /app/model/out.bin /app/model/model.bin");
     if (ret != 0)
     {
-        util::log_error("update_cvs_openvino.py && mv failed with " + ret);
+        util::log_error("Update_cvs_openvino.py && mv failed with " + ret);
         return false;
     }
 
@@ -409,8 +414,6 @@ void AzureEyeModel::handle_h264_output(cv::optional<std::vector<uint8_t>> &out_h
     frame.timestamp = *out_h264_ts;
 
     rtsp::update_data_h264(frame);
-
-    util::log_debug("h264: size=" + std::to_string(out_h264->size()) + ", seqno=" + std::to_string(*out_h264_seqno) + ", ts=" + std::to_string(*out_h264_ts));
 }
 
 cv::gapi::mx::Camera::Mode AzureEyeModel::get_resolution() const

--- a/azureeyemodule/app/model/azureeyemodel.hpp
+++ b/azureeyemodule/app/model/azureeyemodel.hpp
@@ -10,6 +10,7 @@
 
 // Local includes
 #include "parser.hpp"
+#include "../util/helper.hpp"
 #include "../util/timing.hpp"
 
 namespace model {
@@ -121,6 +122,9 @@ protected:
     /** Write the H264 outputs to a file if videofile is non-empty and we have a result ready in the out_264 node. Also writes to the RTSP feed. */
     void handle_h264_output(cv::optional<std::vector<uint8_t>> &out_h264, const cv::optional<int64_t> &out_h264_ts, const cv::optional<int64_t> &out_h264_seqno, std::ofstream &ofs) const;
 
+    /** Use adpative logging to log the inference message so that it does not pollute the log files */
+    void log_inference(const std::string &msg);
+
     /** Save the retraining data if data collection is enabled, this frame lands on the right period, and the confidences are low enough to make it worthwhile. */
     void save_retraining_data(const cv::Mat &original_bgr, const std::vector<float> &confidences);
 
@@ -130,6 +134,9 @@ protected:
 private:
     /** Timer for the data collection stuff. */
     ourtime::Timer data_collection_timer;
+
+    /** Adaptive logger for inference messages. */
+    util::AdaptiveLogger inference_logger;
 
     /** Load potentially several models from a single blob of data (say, if it is a URL that leads to a cascaded model in a .zip file). */
     static bool load(std::string &labelfile, const std::string &data, parser::Parser &modeltype, std::vector<std::string> &blob_files);

--- a/azureeyemodule/app/model/binaryunet.cpp
+++ b/azureeyemodule/app/model/binaryunet.cpp
@@ -45,7 +45,6 @@ void BinaryUnetModel::run(cv::GStreamingCompiled* pipeline)
 
         // Pull data through the pipeline
         bool ran_out_naturally = this->pull_data(*pipeline);
-        util::log_info("pulled through pipeline");
         if (!ran_out_naturally)
         {
             break;
@@ -123,7 +122,7 @@ bool BinaryUnetModel::pull_data(cv::GStreamingCompiled &pipeline)
         ofs.open(this->videofile, std::ofstream::out | std::ofstream::binary | std::ofstream::trunc);
     }
 
-    util::log_info("pull_data: prep to pull");
+    util::log_info("Pull_data: prep to pull");
     // Pull the data from the pipeline while it is running
     while (pipeline.pull(cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_mask)))
     {
@@ -195,32 +194,37 @@ void BinaryUnetModel::preview(cv::Mat &frame, const cv::Mat& last_mask) const
       dst.copyTo(frame);
 }
 
-void BinaryUnetModel::handle_inference_output(const cv::optional<cv::Mat> &out_mask,
-                                    cv::Mat &last_mask,
-                                    float threshold
-                                    ) const
+void BinaryUnetModel::handle_inference_output(const cv::optional<cv::Mat> &out_mask, cv::Mat &last_mask, float threshold)
 {
     if (!out_mask.has_value())
     {
         return;
     }
 
-    // The below objects are on the same desynchronized path
-    // and are coming together
-    CV_Assert(out_mask.has_value());
-
+    // Create a mask - everywhere that the network has confidence greater than threshold
     cv::Mat mask_vals(*out_mask > threshold);
 
+    // Compute the fraction of the image that is occupied by detections
     float relativeOccupied = static_cast<float>(cv::countNonZero(mask_vals)) / (mask_vals.rows * mask_vals.cols);
 
+    // Create JSON message of the following schema
+    //
+    // [
+    //   {
+    //     "occupied": <float> fraction of the image covered by detections
+    //   }
+    // ]
+    //
+    // The outer list is not strictly necessary, but because most (all?) of the other
+    // networks have multiple detections per output, they all use lists, so this one
+    // uses a list just to conform.
     std::string str = std::string("[");
     str.append("{")
-    .append("\"occupied\": \"").append(std::to_string(relativeOccupied)).append("\"")
-    .append("}");
-
+        .append("\"occupied\": \"").append(std::to_string(relativeOccupied)).append("\"")
+        .append("}");
     str.append("]");
     last_mask = std::move(mask_vals);
-    util::log_info(str);
+    this->log_inference(str);
 
     iot::msgs::send_message(iot::msgs::MsgChannel::NEURAL_NETWORK, str);
 }

--- a/azureeyemodule/app/model/binaryunet.hpp
+++ b/azureeyemodule/app/model/binaryunet.hpp
@@ -43,7 +43,7 @@ private:
     void handle_inference_output(const cv::optional<cv::Mat> &out_mask,
                                     cv::Mat &last_mask,
                                     float threshold = 0.5
-                                    ) const;
+                                    );
 
     /** Print out all the model's meta information. */
     void log_parameters() const;

--- a/azureeyemodule/app/model/classification.cpp
+++ b/azureeyemodule/app/model/classification.cpp
@@ -167,8 +167,6 @@ void ClassificationModel::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::
         return;
     }
 
-    util::log_debug("bgr: size=" + util::to_size_string(out_bgr.value()));
-
     last_bgr = *out_bgr;
 
     cv::Mat original_bgr;
@@ -214,7 +212,7 @@ void ClassificationModel::preview(const cv::Mat &rgb, const std::vector<int> &la
 void ClassificationModel::handle_inference_output(const cv::optional<cv::Mat> &out_nn, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
                                                   const cv::optional<std::vector<int>> &out_labels,
                                                   const cv::optional<std::vector<float>> &out_confidences, std::vector<int> &last_labels,
-                                                  std::vector<float> &last_confidences) const
+                                                  std::vector<float> &last_confidences)
 {
     if (!out_nn_ts.has_value())
     {
@@ -228,23 +226,32 @@ void ClassificationModel::handle_inference_output(const cv::optional<cv::Mat> &o
     CV_Assert(out_labels.has_value());
     CV_Assert(out_confidences.has_value());
 
+    // Compose a single message for each detection, which follows this schema:
+    //
+    // {
+    //      "label": string. Class label of the detected object,
+    //      "confidence": float. Confidence of the detection,
+    //      "timestamp": int. Timestamp of the detection.
+    // }
+    //
+    // Push each of these detection messages into a vector.
     std::vector<std::string> messages;
-
     for (std::size_t i = 0; i < out_labels->size(); i++)
     {
-        std::string str = std::string("{");
+        auto label = util::get_label(out_labels.value()[i], this->class_labels);
+        auto confidence = std::to_string(out_confidences.value()[i]);
+        auto timestamp = std::to_string(*out_nn_ts);
 
-        str.append("\"label\": \"").append(util::get_label(out_labels.value()[i], this->class_labels)).append("\", ")
-            .append("\"confidence\": \"").append(std::to_string(out_confidences.value()[i])).append("\", ")
-            .append("\"timestamp\": \"").append(std::to_string(*out_nn_ts)).append("\"")
-            .append("}");
+        std::string str = std::string("{");
+        str.append("\"label\": \"").append(label).append("\", ")
+           .append("\"confidence\": \"").append(confidence).append("\", ")
+           .append("\"timestamp\": \"").append(timestamp).append("\"")
+           .append("}");
 
         messages.push_back(str);
     }
 
-    last_labels = std::move(*out_labels);
-    last_confidences = std::move(*out_confidences);
-
+    // Wrap the detection messages into a list. The send_message() function will wrap it back into curly braces for you.
     std::string str = std::string("[");
     for (size_t i = 0; i < messages.size(); i++)
     {
@@ -256,9 +263,13 @@ void ClassificationModel::handle_inference_output(const cv::optional<cv::Mat> &o
     }
     str.append("]");
 
-    util::log_info("nn: seqno=" + std::to_string(*out_nn_seqno) + ", ts=" + std::to_string(*out_nn_ts) + ", " + str);
-
+    // Send the message over IoT
     iot::msgs::send_message(iot::msgs::MsgChannel::NEURAL_NETWORK, str);
+    this->log_inference(str);
+
+    // Update the cached labels and confidences now that we have new ones.
+    last_labels = std::move(*out_labels);
+    last_confidences = std::move(*out_confidences);
 }
 
 void ClassificationModel::log_parameters() const

--- a/azureeyemodule/app/model/classification.hpp
+++ b/azureeyemodule/app/model/classification.hpp
@@ -50,7 +50,7 @@ private:
     void handle_inference_output(const cv::optional<cv::Mat> &out_nn, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
                                                       const cv::optional<std::vector<int>> &out_labels,
                                                       const cv::optional<std::vector<float>> &out_confidences, std::vector<int> &last_labels,
-                                                      std::vector<float> &last_confidences) const;
+                                                      std::vector<float> &last_confidences);
 
     /** Print out all the model's meta information. */
     void log_parameters() const;

--- a/azureeyemodule/app/model/objectdetector.hpp
+++ b/azureeyemodule/app/model/objectdetector.hpp
@@ -43,7 +43,7 @@ protected:
     virtual void handle_inference_output(const cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
                                          const cv::optional<std::vector<cv::Rect>> &out_boxes, const cv::optional<std::vector<int>> &out_labels,
                                          const cv::optional<std::vector<float>> &out_confidences, const cv::optional<cv::Size> &out_size, std::vector<cv::Rect> &last_boxes, std::vector<int> &last_labels,
-                                         std::vector<float> &last_confidences) const;
+                                         std::vector<float> &last_confidences);
 
     /** Pull data through the given pipeline. Returns true if we run out of frames, false if we have been interrupted. Otherwise runs forever. */
     virtual bool pull_data(cv::GStreamingCompiled &pipeline);

--- a/azureeyemodule/app/model/ocr.cpp
+++ b/azureeyemodule/app/model/ocr.cpp
@@ -177,11 +177,8 @@ void OCRModel::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_b
     // BGR output: visualize and optionally display
     if (!out_bgr.has_value())
     {
-        util::log_debug("debug: out_bgr does not have value");
         return;
     }
-
-    util::log_debug("bgr: size=" + util::to_size_string(out_bgr.value()));
 
     last_bgr = *out_bgr;
 
@@ -193,7 +190,6 @@ void OCRModel::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_b
 
     if (this->status_msg.empty())
     {
-        std::cout<<"Updating Data Result using RTSP"<<std::endl;
         rtsp::update_data_result(last_bgr);
     }
     else
@@ -260,8 +256,8 @@ void OCRModel::handle_inference_output(const cv::optional<int64_t> &out_nn_ts, c
     {
         // Decode the recognized text in the rectangle
         auto decoded = this->OCRDecoder.decode(temp_text[label_idx]);
-        util::log_info("text: \"" + decoded.text + "\"");
-        if(decoded.conf > 0.2)
+        this->log_inference("Text: \"" + decoded.text + "\"");
+        if (decoded.conf > 0.2)
         {
             curr_textresults.push_back(decoded.text);
             curr_rcsresults.push_back(temp_rcs[label_idx]);
@@ -283,7 +279,7 @@ void OCRModel::handle_inference_output(const cv::optional<int64_t> &out_nn_ts, c
 
     msg.append("]}");
 
-    // Send all result into last_text and then dump all curr text res
+    // Send all result into last_text and then dump all curr text results
     if(curr_textresults.size() > 0)
     {
         last_text = std::move(curr_textresults);
@@ -295,7 +291,7 @@ void OCRModel::handle_inference_output(const cv::optional<int64_t> &out_nn_ts, c
         last_rcs = {};
     }
 
-    util::log_info("nn: seqno=" + std::to_string(*out_nn_seqno) + ", ts=" + std::to_string(*out_nn_ts) + ", " + msg);
+    // Send resulting message over IoT
     iot::msgs::send_message(iot::msgs::MsgChannel::NEURAL_NETWORK, msg);
 }
 

--- a/azureeyemodule/app/model/openpose.cpp
+++ b/azureeyemodule/app/model/openpose.cpp
@@ -192,8 +192,6 @@ void OpenPoseModel::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &l
         return;
     }
 
-    util::log_debug("bgr: size=" + util::to_size_string(out_bgr.value()));
-
     last_bgr = *out_bgr;
 
     cv::Mat original_bgr;
@@ -270,7 +268,7 @@ void OpenPoseModel::preview(cv::Mat &bgr, const std::vector<pose::HumanPose> &po
 }
 
 void OpenPoseModel::handle_inference_output(const cv::optional<cv::Mat> &out_nn, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
-                                            const cv::optional<std::vector<pose::HumanPose>> &out_poses, std::vector<pose::HumanPose> &last_poses) const
+                                            const cv::optional<std::vector<pose::HumanPose>> &out_poses, std::vector<pose::HumanPose> &last_poses)
 {
     if (!out_nn_ts.has_value())
     {
@@ -300,7 +298,7 @@ void OpenPoseModel::handle_inference_output(const cv::optional<cv::Mat> &out_nn,
 
     last_poses = std::move(*out_poses);
 
-    util::log_info("nn: seqno=" + std::to_string(*out_nn_seqno) + ", ts=" + std::to_string(*out_nn_ts) + ", " + msg);
+    this->log_inference(msg);
     iot::msgs::send_message(iot::msgs::MsgChannel::NEURAL_NETWORK, msg);
 }
 

--- a/azureeyemodule/app/model/openpose.hpp
+++ b/azureeyemodule/app/model/openpose.hpp
@@ -30,7 +30,7 @@ private:
 
     /** Handle the pose estimation model's output */
     void handle_inference_output(const cv::optional<cv::Mat> &out_nn, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
-                                                const cv::optional<std::vector<pose::HumanPose>> &out_poses, std::vector<pose::HumanPose> &last_poses) const;
+                                                const cv::optional<std::vector<pose::HumanPose>> &out_poses, std::vector<pose::HumanPose> &last_poses);
 
     /** Print out all the model's meta information. */
     void log_parameters() const;

--- a/azureeyemodule/app/streaming/rtsp.cpp
+++ b/azureeyemodule/app/streaming/rtsp.cpp
@@ -295,16 +295,6 @@ static void need_data_callback(GstElement *appsrc, guint unused, StreamParameter
     GST_BUFFER_DURATION(buffer) = gst_util_uint64_scale_int(1, GST_SECOND, params->fps);
     params->timestamp += GST_BUFFER_DURATION(buffer);
 
-    // Debug log the time stamp
-    if (params->stream_type == StreamType::RAW)
-    {
-        util::log_debug("RTSP buffer pushed to RAW with timestamp " + std::to_string(params->timestamp / 1000000) + " (ms)");
-    }
-    else if (params->stream_type == StreamType::RESULT)
-    {
-        util::log_debug("RTSP buffer pushed to RESULT with timestamp " + std::to_string(params->timestamp / 1000000) + " (ms)");
-    }
-
     // Push the RGB frame into the pipeline
     GstFlowReturn ret;
     g_signal_emit_by_name(appsrc, "push-buffer", buffer, &ret);
@@ -350,10 +340,6 @@ static void need_data_callback_h264(GstElement *appsrc, guint unused, StreamPara
     if (ret != GST_FLOW_OK)
     {
         util::log_error("Got an unexpected return value from pushing the h.264 frame to Gstreamer pipeline: " + std::to_string(ret));
-    }
-    else
-    {
-        util::log_debug("RTSP buffer pushed to H.264 with size " + std::to_string(size) + " and timestamp " + std::to_string(frame.timestamp));
     }
 
     // If we have any more frames behind this one, let's pop this one.

--- a/azureeyemodule/app/util/helper.hpp
+++ b/azureeyemodule/app/util/helper.hpp
@@ -3,8 +3,12 @@
 #pragma once
 
 // Standard library includes
+#include <chrono>
+#include <ctime>
 #include <cstdlib>
 #include <string>
+#include <tuple>
+#include <unordered_map>
 #include <vector>
 
 // Third party includes
@@ -23,13 +27,13 @@ constexpr std::size_t array_size(const T (&)[N]) noexcept {
 bool file_exists(const std::string &filename);
 
 /** Log an error */
-void log_error(std::string str);
+void log_error(const std::string &str);
 
 /** Log an info */
-void log_info(std::string str);
+void log_info(const std::string &str);
 
 /** Log a debug */
-void log_debug(std::string str);
+void log_debug(const std::string &str);
 
 /** Get a class label from the given vector or return the string representation of the ID. */
 std::string get_label(int index, const std::vector<std::string> &class_list);
@@ -63,5 +67,44 @@ void version();
 
 /** Splices a comma-separated list into a list of strings. */
 std::vector<std::string> splice_comma_separated_list(const std::string &list_string);
+
+/**
+ * You can use this class to log messages such that messages that are logged too frequently are
+ * filtered out.
+ *
+ * After creating an instance of this class, the first two times you log a message through
+ * it will be like normal. But the third and subsequent times may or may not actually
+ * log the message, depending on the frequency with which you are calling the logging function.
+ *
+ * The logging will get slower and slower over time until it maxes out at one message per 10 minutes.
+ */
+class AdaptiveLogger
+{
+public:
+    /** Constructor */
+    AdaptiveLogger();
+
+    /** Log at INFO level. May or may not actually log, depending on the frequency with which you are calling this method with this exact log message. */
+    void log_info(const std::string &msg);
+
+    /** Log at ERROR level. May or may not actually log, depending on the frequency with which you are calling this method with this exact log message. */
+    void log_error(const std::string &msg);
+
+    /** Log at DEBUG level. May or may not actually log, depending on the frequency with which you are calling this method with this exact log message. */
+    void log_debug(const std::string &msg);
+
+private:
+    /** The maximum number of milliseconds between successful logs. */
+    std::chrono::milliseconds maximum = std::chrono::milliseconds(1000 * 60 * 10);
+
+    /** The timestamp of the last message that was logged successfully (i.e., not filtered). */
+    std::chrono::milliseconds last_timestamp;
+
+    /** The current number of milliseconds that must pass before we log again through this filter. */
+    std::chrono::milliseconds threshold;
+
+    /** Adjusts the internal threshold for logging frequency. */
+    bool adapt();
+};
 
 } // namespace util


### PR DESCRIPTION
This commit adds an "adaptive" logger to the AzureEyeModel base class
that lets its derived classes log their inference messages in a decaying
frequency.

IoT messages are unchanged.