### PR TITLE
Fix bug with Custom Vision classifier

### DIFF
--- a/azureeyemodule/app/kernels/classification_kernels.cpp
+++ b/azureeyemodule/app/kernels/classification_kernels.cpp
@@ -17,9 +17,9 @@ namespace gapi {
 namespace streaming {
 
 /** C++ wrapper for classification op */
-GClassificationsWithConf parseClass(const GMat& in, const GOpaque<Size>& in_sz, float confidence_threshold)
+GClassificationsWithConf parse_class(const GMat& in)
 {
-    return GParseClass::on(in, in_sz, confidence_threshold);
+    return GParseClass::on(in);
 }
 
 } // namespace streaming

--- a/azureeyemodule/app/model/classification.cpp
+++ b/azureeyemodule/app/model/classification.cpp
@@ -3,6 +3,7 @@
 
 // Standard library includes
 #include <fstream>
+#include <functional>
 #include <thread>
 
 // Third party includes
@@ -37,10 +38,13 @@ void ClassificationModel::run(cv::GStreamingCompiled* pipeline)
 {
     while (true)
     {
+        // We must wait for the Myriad X VPU to come up.
         this->wait_for_device();
 
         // Read in the labels for classification
         label::load_label_file(this->class_labels, this->labelfpath);
+
+        // Now let's log our model's parameters.
         this->log_parameters();
 
         // Build the camera pipeline with G-API
@@ -60,50 +64,57 @@ void ClassificationModel::run(cv::GStreamingCompiled* pipeline)
 
 cv::GStreamingCompiled ClassificationModel::compile_cv_graph() const
 {
-    // Declare an empty GMat - the beginning of the pipeline
+    // The input node of the G-API pipeline. This will be filled in, one frame at a time.
     cv::GMat in;
+
+    // We have a custom preprocessing node for the Myriad X-attached camera.
     cv::GMat preproc = cv::gapi::mx::preproc(in, this->resolution);
+
+    // This path is the H.264 path. It gets our frames one at a time from
+    // the camera and encodes them into H.264.
     cv::GArray<uint8_t> h264;
     cv::GOpaque<int64_t> h264_seqno;
     cv::GOpaque<int64_t> h264_ts;
     std::tie(h264, h264_seqno, h264_ts) = cv::gapi::streaming::encH264ts(preproc);
 
-    // We have BGR output and H264 output in the same graph.
-    // In this case, BGR always must be desynchronized from the main path
-    // to avoid internal queue overflow (FW reports this data to us via
-    // separate channels)
-    // copy() is required only to maintain the graph contracts
-    // (there must be an operation following desync()). No real copy happens
+    // We branch off from the preproc node into H.264 (above), raw BGR output (here),
+    // and neural network inferences (below).
     cv::GMat img = cv::gapi::copy(cv::gapi::streaming::desync(preproc));
+    auto img_ts = cv::gapi::streaming::timestamp(img);
 
-    // This branch has inference and is desynchronized to keep
-    // a constant framerate for the encoded stream (above)
+    // This node branches off from the preproc node for neural network inferencing.
     cv::GMat bgr = cv::gapi::streaming::desync(preproc);
+    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(bgr);
 
+    // Here's where we actually run the neural network. It runs on the VPU.
     cv::GMat nn = cv::gapi::infer<ClassificationNetwork>(bgr);
 
+    // Grab some useful information: the frame number, the timestamp, and the size of the frame.
     cv::GOpaque<int64_t> nn_seqno = cv::gapi::streaming::seqNo(nn);
-    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(nn);
     cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(bgr);
 
+    // Parse the output of the classification network into class IDs and confidence scores.
     cv::GArray<int> ids;
     cv::GArray<float> cfs;
-    std::tie(ids, cfs) = cv::gapi::streaming::parseClass(nn, sz);
+    std::tie(ids, cfs) = cv::gapi::streaming::parse_class(nn);
 
-    // Now specify the computation's boundaries
+    // Specify the boundaries of the G-API graph (the inputs and outputs).
     auto graph = cv::GComputation(cv::GIn(in),
-                                    cv::GOut(h264, h264_seqno, h264_ts,      // main path: H264 (~constant framerate)
-                                    img,                                     // desynchronized path: BGR
-                                    nn_seqno, nn_ts, ids, cfs));
+                                  cv::GOut(h264, h264_seqno, h264_ts,    // H.264 branch
+                                           img, img_ts,                  // Raw BGR frames branch
+                                           nn_seqno, nn_ts, ids, cfs));  // Neural network inferences path
 
+    // Pass the actual neural network blob file into the graph. We assume we have a modelfiles of length at least 1.
+    CV_Assert(this->modelfiles.size() >= 1);
     auto networks = cv::gapi::networks(cv::gapi::mx::Params<ClassificationNetwork>{this->modelfiles.at(0)});
 
+    // Here we wrap up all the kernels (the implementations of the G-API ops) that we need for our graph.
     auto kernels = cv::gapi::combine(cv::gapi::mx::kernels(), cv::gapi::kernels<cv::gapi::streaming::GOCVParseClass>());
 
-    // Compile the graph in streamnig mode, set all the parameters
+    // Compile the graph in streamnig mode; set all the parameters; feed the firmware file into the VPU.
     auto pipeline = graph.compileStreaming(cv::gapi::mx::Camera::params(), cv::compile_args(networks, kernels, cv::gapi::mx::mvcmdFile{ this->mvcmd }));
 
-    // Specify the Azure Percept's Camera as the input to the pipeline, and start processing
+    // Specify the Azure Percept's Camera as the input to the pipeline.
     pipeline.setSource(cv::gapi::wip::make_src<cv::gapi::mx::Camera>());
 
     return pipeline;
@@ -111,33 +122,40 @@ cv::GStreamingCompiled ClassificationModel::compile_cv_graph() const
 
 bool ClassificationModel::pull_data(cv::GStreamingCompiled &pipeline)
 {
+    // The raw BGR frames from the camera will fill this node.
     cv::optional<cv::Mat> out_bgr;
+    cv::optional<int64_t> out_bgr_ts;
 
+    // The H.264 information will fill these nodes.
     cv::optional<std::vector<uint8_t>> out_h264;
     cv::optional<int64_t> out_h264_seqno;
     cv::optional<int64_t> out_h264_ts;
 
-    cv::optional<cv::Mat> out_nn;
+    // Our neural network's outputs will fill these nodes.
     cv::optional<int64_t> out_nn_ts;
     cv::optional<int64_t> out_nn_seqno;
     cv::optional<std::vector<int>> out_labels;
     cv::optional<std::vector<float>> out_confidences;
 
+    // Because each node is asynchronusly filled, we cache them whenever we get them.
     std::vector<int> last_labels;
     std::vector<float> last_confidences;
     cv::Mat last_bgr;
 
+    // If the user wants to record a video, we open the video file.
     std::ofstream ofs;
     if (!this->videofile.empty())
     {
         ofs.open(this->videofile, std::ofstream::out | std::ofstream::binary | std::ofstream::trunc);
     }
 
-    // Pull the data from the pipeline while it is running
-    while (pipeline.pull(cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_nn_seqno, out_nn_ts, out_labels, out_confidences)))
+    // Pull the data from the pipeline while it is running.
+    // Every time we call pull(), G-API gives us whatever nodes it has ready.
+    // So we have to make sure a node has useful contents before using it.
+    while (pipeline.pull(cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_bgr_ts, out_nn_seqno, out_nn_ts, out_labels, out_confidences)))
     {
         this->handle_h264_output(out_h264, out_h264_ts, out_h264_seqno, ofs);
-        this->handle_inference_output(out_nn, out_nn_ts, out_nn_seqno, out_labels, out_confidences, last_labels, last_confidences);
+        this->handle_inference_output(out_nn_ts, out_nn_seqno, out_labels, out_confidences, last_labels, last_confidences);
         this->handle_bgr_output(out_bgr, last_bgr, last_labels, last_confidences);
 
         if (restarting)
@@ -154,7 +172,6 @@ bool ClassificationModel::pull_data(cv::GStreamingCompiled &pipeline)
 
 void ClassificationModel::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_bgr, const std::vector<int> &last_labels, const std::vector<float> &last_confidences)
 {
-    // BGR output: visualize and optionally display
     if (!out_bgr.has_value())
     {
         return;
@@ -166,7 +183,7 @@ void ClassificationModel::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::
     last_bgr.copyTo(original_bgr);
 
     rtsp::update_data_raw(last_bgr);
-    preview(last_bgr, last_labels, last_confidences);
+    this->preview(last_bgr, last_labels, last_confidences);
 
     if (this->status_msg.empty())
     {
@@ -180,41 +197,63 @@ void ClassificationModel::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::
         util::put_text(bgr_with_status, this->status_msg);
         rtsp::update_data_result(bgr_with_status);
     }
-
-    // Maybe save and export the retraining data at this point
-    this->save_retraining_data(original_bgr, last_confidences);
 }
 
 void ClassificationModel::preview(const cv::Mat &rgb, const std::vector<int> &labels, const std::vector<float> &confidences) const
 {
+    const auto threshold_confidence = 0.5f;
+    auto largest_confidence = 0.0f;
+    int best_label = 0;
+
+    // Go through each class and see if we have found anything larger than threshold,
+    // and keep the largest-confidence detection if so.
     for (std::size_t i = 0; i < labels.size(); i++)
     {
-        // color of a label
-        int index = labels[i] % label::colors().size();
-
-        cv::putText(rgb,
-            util::get_label(labels[i], this->class_labels) + ": " + util::to_string_with_precision(confidences[i], 2),
-            cv::Point(0, i * 20) + cv::Point(3, 20),
-            cv::FONT_HERSHEY_SIMPLEX,
-            0.7,
-            cv::Scalar(label::colors().at(index)),
-            2);
+        if (confidences.at(i) > largest_confidence)
+        {
+            largest_confidence = confidences.at(i);
+            best_label = labels.at(i);
+        }
     }
+
+    // Get a new color for each item we detect,
+    // though wrap around if there are a whole bunch of items.
+    auto color_index = (largest_confidence >= threshold_confidence) ? best_label % label::colors().size() : 0;
+
+    // Draw the label. Use the same color. If we can't figure out the label
+    // (because the network output something unexpected, or there is no labels file),
+    // we just use the class index.
+    std::string label;
+    if (largest_confidence >= threshold_confidence)
+    {
+        label = util::get_label(best_label, this->class_labels) + ": " + util::to_string_with_precision(largest_confidence, 2);
+    }
+    else
+    {
+        label = "No Detections";
+    }
+
+    auto origin = cv::Point(0, 20) + cv::Point(3, 20);
+    auto font = cv::FONT_HERSHEY_SIMPLEX;
+    auto fontscale = 0.7;
+    auto color = cv::Scalar(label::colors().at(color_index));
+    auto thickness = 2;
+    cv::putText(rgb, label, origin, font, fontscale, color, thickness);
 }
 
-void ClassificationModel::handle_inference_output(const cv::optional<cv::Mat> &out_nn, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
+void ClassificationModel::handle_inference_output(const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
                                                   const cv::optional<std::vector<int>> &out_labels,
                                                   const cv::optional<std::vector<float>> &out_confidences, std::vector<int> &last_labels,
                                                   std::vector<float> &last_confidences)
+
 {
     if (!out_nn_ts.has_value())
     {
         return;
     }
 
-    // The below objects are on the same desynchronized path
-    // and are coming together
-    CV_Assert(out_nn_ts.has_value());
+    // All of these items are derived together on the same branch of the G-API graph, so they
+    // should all arrive together.
     CV_Assert(out_nn_seqno.has_value());
     CV_Assert(out_labels.has_value());
     CV_Assert(out_confidences.has_value());
@@ -258,11 +297,14 @@ void ClassificationModel::handle_inference_output(const cv::optional<cv::Mat> &o
 
     // Send the message over IoT
     iot::msgs::send_message(iot::msgs::MsgChannel::NEURAL_NETWORK, str);
+
+    // Log using decaying filter so that the frequency of log messages goes down over time. This is to keep
+    // the logs from getting out of hand on the device.
     this->log_inference(str);
 
     // Update the cached labels and confidences now that we have new ones.
-    last_labels = std::move(*out_labels);
-    last_confidences = std::move(*out_confidences);
+    last_labels = *out_labels;
+    last_confidences = *out_confidences;
 }
 
 void ClassificationModel::log_parameters() const

--- a/azureeyemodule/app/model/classification.hpp
+++ b/azureeyemodule/app/model/classification.hpp
@@ -47,7 +47,7 @@ private:
     void preview(const cv::Mat& rgb, const std::vector<int>& labels, const std::vector<float>& confidences) const;
 
     /** Handle the detector's output */
-    void handle_inference_output(const cv::optional<cv::Mat> &out_nn, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
+    void handle_inference_output(const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
                                                       const cv::optional<std::vector<int>> &out_labels,
                                                       const cv::optional<std::vector<float>> &out_confidences, std::vector<int> &last_labels,
                                                       std::vector<float> &last_confidences);


### PR DESCRIPTION
Prior to this commit, we were not handling the Custom Vision classification model's output correctly. The output of the Custom Vision classifier is a tensor of shape (1, 1, 1, N), with N being the number of classes. We were iterating over dim[1], but should have been iterating over dim[3] for the confidence scores.

The new expected behavior for this model is to draw the top confidence label on the result stream, unless the confidence of that label is lower than 0.5, in which case we write "no detections". Regardless, we always send all confidence scores over IoT messages.