### PR TITLE
Fix IoT Hub messages to be JSON format and utf-8 encoded.

### DIFF
--- a/azureeyemodule/app/iot/iot_interface.cpp
+++ b/azureeyemodule/app/iot/iot_interface.cpp
@@ -257,6 +257,18 @@ static void send_iot_msg(IOTHUB_MODULE_CLIENT_LL_HANDLE client_handle, const Msg
         util::log_error("Could not set correlation ID for Azure IoT message we are trying to send. Msg ID: " + std::to_string(message_instance.tracking_id));
     }
 
+    result = IoTHubMessage_SetContentTypeSystemProperty(message_instance.handle, "application%2fjson");
+    if (result != IOTHUB_MESSAGE_OK)
+    {
+        util::log_error("Could not set content type for Azure IoT message we are trying to send. Msg ID: " + std::to_string(message_instance.tracking_id));
+    }
+
+    result = IoTHubMessage_SetContentEncodingSystemProperty(message_instance.handle, "utf-8");
+    if (result != IOTHUB_MESSAGE_OK)
+    {
+        util::log_error("Could not set content encoding for Azure IoT message we are trying to send. Msg ID: " + std::to_string(message_instance.tracking_id));
+    }
+
     auto res = IoTHubModuleClient_LL_SendEventToOutputAsync(client_handle, message_instance.handle, "AzureEyeModuleOutput", azure_iot_send_msg_callback, &message_instance);
     if (res != IOTHUB_CLIENT_OK)
     {


### PR DESCRIPTION
Originally it was sending the content in base64 format to IoT Hub. 
And the content is non human readable if we routed to Azure storage. (Fig. 1)
The pull request is to fix the content encoding from base64 to utf-8 and make it readable. (Fig. 2)


| Fig.1 |
| :---   |
| <img width="844" alt="Screenshot 2021-04-29 142918" src="https://user-images.githubusercontent.com/4483984/116510419-74820a80-a8f7-11eb-9877-7e0658cadbdc.png"> |

| Fig.2 |
| :---   |
| <img width="847" alt="Screenshot 2021-04-29 143208" src="https://user-images.githubusercontent.com/4483984/116510579-b57a1f00-a8f7-11eb-9cab-d20a7b451517.png"> |

