### PR TITLE
This commit adds a new time-alignment feature

### DIFF
--- a/azureeyemodule/README.md
+++ b/azureeyemodule/README.md
@@ -144,6 +144,10 @@ These are the allowed values for this IoT Module's twin:
 * `StreamResolution`: String. Must be one of `native`, `1080p`, or `720p`. Sets the resolution of the camera feed.
 * `TelemetryIntervalNeuralNetworkMs`: Integer. Determines how often to send messages from the neural network. Sends a message at most once every this
   many milliseconds. Please note that Azure subscriptions have a limited number of messages per day (depending on the subscription tier).
+* `TimeAlignRTSP`: Boolean. If true, we will align the RTSP raw frames with the RTSP result frames. This will cause a latency in the stream
+  equal to the amount of time it takes for your neural network to inference each frame. If false, there is no latency, but the results
+  for a frame may be written on top of frames that are farther ahead in time, leading to a noticeable lag in the results on the RTSP stream overlay.
+  This will be especially noticeable with long-latency networks, such as Faster RCNN.
 
 ## Code Flow
 

--- a/azureeyemodule/app/iot/iot_interface.cpp
+++ b/azureeyemodule/app/iot/iot_interface.cpp
@@ -177,7 +177,7 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT receive_onvif_message(IOTHUB_MESSAGE_HAN
             return IOTHUBMESSAGE_REJECTED;
         }
     }
-           
+
 
     if (json_object_get_value(root_object, "-fps") != nullptr)
     {
@@ -197,15 +197,15 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT receive_onvif_message(IOTHUB_MESSAGE_HAN
 
     if (json_object_get_value(root_object, "-s") != nullptr)
     {
-        std::string value  = json_object_get_string(root_object, "-s");
+        std::string value = json_object_get_string(root_object, "-s");
         if (rtsp::is_valid_resolution(std::string(value)))
         {
             // change the model resolution
-            iot::update::restart_model_with_new_resolution(std::string(value));
+            iot::update::restart_model_with_new_resolution(rtsp::resolution_string_to_enum(std::string(value)));
 
             // reset the rtsp stream resolution, and then disconnect the stream to let the new parameter can be loaded
-            rtsp::set_stream_params(rtsp::StreamType::RAW, std::string(value), false);
-            rtsp::set_stream_params(rtsp::StreamType::RESULT, std::string(value), false);
+            rtsp::set_stream_params(rtsp::StreamType::RAW, rtsp::resolution_string_to_enum(std::string(value)), false);
+            rtsp::set_stream_params(rtsp::StreamType::RESULT, rtsp::resolution_string_to_enum(std::string(value)), false);
 
             // restart the rtsp stream
             rtsp::set_stream_params(rtsp::StreamType::RAW,  true);
@@ -378,7 +378,7 @@ void stop_iot()
         // with a timeout, and keep trying until it works or we try so many times that
         // it is clear it will not work in a reasonable amount of time.
         const auto max_kill_tries = 10; // arbitrarily chosen - the best way to choose stuff!
-        for(auto i = 0; i < max_kill_tries; i++)
+        for (auto i = 0; i < max_kill_tries; i++)
         {
             // Send the kill message
             util::log_info("Killing IoT connection.");

--- a/azureeyemodule/app/iot/iot_update.hpp
+++ b/azureeyemodule/app/iot/iot_update.hpp
@@ -6,6 +6,9 @@
  */
 #pragma once
 
+// Local includes
+#include "../streaming/resolution.hpp"
+
 // Standard library includes
 #include <string>
 
@@ -25,13 +28,16 @@ typedef void (*update_collection_params_cb_t)(bool, unsigned long int);
 typedef void (*update_telemetry_interval_cb_t)(unsigned long int);
 
 /** A convenience typedef for the type of function we need to update the resolution in the AI model. */
-typedef void (*update_resolution_cb_t)(const std::string &);
+typedef void (*update_resolution_cb_t)(const rtsp::Resolution &);
+
+/** A convenience typedef for the type of function we need to update the time alignment feature. */
+typedef void (*update_time_alignment_cb_t)(bool);
 
 /** Initialize the module twin update callback using the given IoT handle. */
 void initialize(IOTHUB_MODULE_CLIENT_LL_HANDLE client_handle);
 
 /** Restart the AI model with the new resolution. */
-void restart_model_with_new_resolution(const std::string &resolution);
+void restart_model_with_new_resolution(const rtsp::Resolution &resolution);
 
 /** Set the update callback function. This callback will be called to alert us to update the AI model. */
 void set_update_callback(update_cb_t callback);
@@ -44,6 +50,9 @@ void set_update_resolution_callback(update_resolution_cb_t callback);
 
 /** Set the callback function that gets called when the telemetry intervals update. */
 void set_update_telemetry_intervals_callback(update_telemetry_interval_cb_t callback);
+
+/** Set the callback function that gets called when the time alignment feature gets updated. */
+void set_update_time_alignment_callback(update_time_alignment_cb_t callback);
 
 } // namespace update
 } // namespace iot

--- a/azureeyemodule/app/model/binaryunet.cpp
+++ b/azureeyemodule/app/model/binaryunet.cpp
@@ -3,6 +3,7 @@
 
 // Standard library includes
 #include <fstream>
+#include <functional>
 #include <thread>
 
 // Third party includes
@@ -23,22 +24,26 @@
 
 namespace model {
 
-/** A classification network takes a single input and outputs a single output (which we will parse into labels and confidences) */
+/** This network takes in a single frame at a time and outputs a frame (a segmentation mask). */
 G_API_NET(UNetNetwork, <cv::GMat(cv::GMat)>, "unet-network");
 
 BinaryUnetModel::BinaryUnetModel(const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution)
     : AzureEyeModel( modelfpaths, mvcmd, videofile, resolution )
 {
+    // Nothing to do. Everything's done via the parent class's constructor.
 }
 
 void BinaryUnetModel::run(cv::GStreamingCompiled* pipeline)
 {
     while (true)
     {
+        // We must wait for the Myriad X VPU to come up.
         this->wait_for_device();
+
+        // Now let's log our model's parameters.
         this->log_parameters();
 
-        // Build the camera pipeline with G-API
+        // Build the camera pipeline with G-API and start it.
         *pipeline = this->compile_cv_graph();
         util::log_info("starting segmentation pipeline...");
         pipeline->start();
@@ -54,46 +59,51 @@ void BinaryUnetModel::run(cv::GStreamingCompiled* pipeline)
 
 cv::GStreamingCompiled BinaryUnetModel::compile_cv_graph() const
 {
-    // Declare an empty GMat - the beginning of the pipeline
+    // The input node of the G-API pipeline. This will be filled in, one frame at time.
     cv::GMat in;
+
+    // We have a custom preprocessing node for the Myriad X-attached camera.
     cv::GMat preproc = cv::gapi::mx::preproc(in, this->resolution);
+
+    // This path is the H.264 path. It gets our frames one at a time from
+    // the camera and encodes them into H.264.
     cv::GArray<uint8_t> h264;
     cv::GOpaque<int64_t> h264_seqno;
     cv::GOpaque<int64_t> h264_ts;
     std::tie(h264, h264_seqno, h264_ts) = cv::gapi::streaming::encH264ts(preproc);
 
-    // We have BGR output and H264 output in the same graph.
-    // In this case, BGR always must be desynchronized from the main path
-    // to avoid internal queue overflow (FW reports this data to us via
-    // separate channels)
-    // copy() is required only to maintain the graph contracts
-    // (there must be an operation following desync()). No real copy happens
+    // We branch off from the preproc node into H.264 (above), raw BGR output (here),
+    // and neural network inferences (below).
     cv::GMat img = cv::gapi::copy(cv::gapi::streaming::desync(preproc));
+    auto img_ts = cv::gapi::streaming::timestamp(img);
 
-    // This branch has inference and is desynchronized to keep
-    // a constant framerate for the encoded stream (above)
+    // This node branches off from the preproc node for neural network inferencing.
     cv::GMat bgr = cv::gapi::streaming::desync(preproc);
+    auto nn_ts = cv::gapi::streaming::timestamp(bgr);
 
+    // Here's where we actually run our neural network. It runs on the VPU.
     cv::GMat segmentation = cv::gapi::infer<UNetNetwork>(bgr);
 
-    cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(bgr);
-
+    // Here's where we post-process our network's outputs into a segmentation mask.
     cv::GMat mask = cv::gapi::streaming::PostProcBinaryUnet::on(segmentation);
 
-    // Now specify the computation's boundaries
+    // Specify the boundaries of the G-API graph (the inputs and outputs).
     auto graph = cv::GComputation(cv::GIn(in),
-                                    cv::GOut(h264, h264_seqno, h264_ts,      // main path: H264 (~constant framerate)
-                                    img,                                     // desynchronized path: BGR
-                                    mask));
+                                  cv::GOut(h264, h264_seqno, h264_ts,      // H.264 path
+                                           img, img_ts,                    // Raw BGR frames path
+                                           mask, nn_ts));                  // Neural network inference path
 
+    // Pass the actual neural network blob file into the graph. We assume we have a modelfiles of length at least 1.
+    CV_Assert(this->modelfiles.size() >= 1);
     auto networks = cv::gapi::networks(cv::gapi::mx::Params<UNetNetwork>{this->modelfiles.at(0)});
 
+    // Here we wrap up all the kernels (the implementations of the G-API ops) that we need for our graph.
     auto kernels = cv::gapi::combine(cv::gapi::mx::kernels(), cv::gapi::kernels<cv::gapi::streaming::GOCVPostProcBinaryUnet>());
 
-    // Compile the graph in streamnig mode, set all the parameters
+    // Compile the graph in streamnig mode; set all the parameters; feed the firmware file into the VPU.
     auto pipeline = graph.compileStreaming(cv::gapi::mx::Camera::params(), cv::compile_args(networks, kernels, cv::gapi::mx::mvcmdFile{ this->mvcmd }));
 
-    // Specify the AzureEye's Camera as the input to the pipeline, and start processing
+    // Specify the Percept DK's camera as the input to the pipeline.
     pipeline.setSource(cv::gapi::wip::make_src<cv::gapi::mx::Camera>());
 
     util::log_info("Succesfully compiled segmentation pipeline");
@@ -102,17 +112,24 @@ cv::GStreamingCompiled BinaryUnetModel::compile_cv_graph() const
 
 bool BinaryUnetModel::pull_data(cv::GStreamingCompiled &pipeline)
 {
+    // The raw BGR frames from the camera will fill this node.
     cv::optional<cv::Mat> out_bgr;
+    cv::optional<int64_t> out_bgr_ts;
 
+    // The H.264 information will fill these nodes.
     cv::optional<std::vector<uint8_t>> out_h264;
     cv::optional<int64_t> out_h264_seqno;
     cv::optional<int64_t> out_h264_ts;
 
+    // Our neural network's frames will fill out_mask, and timestamp will fill nn_ts.
     cv::optional<cv::Mat> out_mask;
+    cv::optional<int64_t> out_nn_ts;
 
+    // Because each node is asynchronusly filled, we cache them whenever we get them.
     cv::Mat last_bgr;
     cv::Mat last_mask;
 
+    // If the user wants to record a video, we open the video file.
     std::ofstream ofs;
     if (!this->videofile.empty())
     {
@@ -120,14 +137,17 @@ bool BinaryUnetModel::pull_data(cv::GStreamingCompiled &pipeline)
     }
 
     util::log_info("Pull_data: prep to pull");
-    // Pull the data from the pipeline while it is running
-    while (pipeline.pull(cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_mask)))
+
+    // Pull the data from the pipeline while it is running.
+    // Every time we call pull(), G-API gives us whatever nodes it has ready.
+    // So we have to make sure a node has useful contents before using it.
+    while (pipeline.pull(cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_bgr_ts, out_mask, out_nn_ts)))
     {
         this->handle_h264_output(out_h264, out_h264_ts, out_h264_seqno, ofs);
-        this->handle_inference_output(out_mask, last_mask, 0.5);
-        this->handle_bgr_output(out_bgr, last_bgr, last_mask);
+        this->handle_inference_output(out_mask, out_nn_ts, last_mask);
+        this->handle_bgr_output(out_bgr, out_bgr_ts, last_bgr, last_mask);
 
-        if (restarting)
+        if (this->restarting)
         {
             // We've been interrupted
             this->cleanup(pipeline, last_bgr);
@@ -139,63 +159,80 @@ bool BinaryUnetModel::pull_data(cv::GStreamingCompiled &pipeline)
     return true;
 }
 
-void BinaryUnetModel::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_bgr,  const cv::Mat &last_mask)
+void BinaryUnetModel::handle_bgr_output(const cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &bgr_ts, cv::Mat &last_bgr, const cv::Mat &last_mask)
 {
-    // BGR output: visualize and optionally display
+    // If out_bgr does not have anything in it, we didn't get anything from the G-API graph at this iteration.
     if (!out_bgr.has_value())
     {
         return;
     }
 
-    last_bgr = *out_bgr;
-    rtsp::update_data_raw(last_bgr);
+    // This comes with out_bgr on the same branch of the G-API graph, so it must have a value if out_bgr does.
+    CV_Assert(bgr_ts.has_value());
 
-    // draw on the bgr
-    if(!last_mask.empty()) {
-        preview(last_bgr, last_mask);
-    }
-    rtsp::update_data_result(last_bgr);
+    // Now that we got a useful value, let's cache this one as the most recent.
+    last_bgr = *out_bgr;
+
+    // Mark up this frame with our preview function.
+    cv::Mat marked_up_bgr;
+    last_bgr.copyTo(marked_up_bgr);
+    this->preview(marked_up_bgr, last_mask);
+
+    // Stream the latest BGR frame.
+    this->stream_frames(last_bgr, marked_up_bgr, bgr_ts);
+
+    // Maybe save and export the retraining data at this point
+    this->save_retraining_data(last_bgr);
 }
 
 void BinaryUnetModel::preview(cv::Mat &frame, const cv::Mat& last_mask) const
 {
-      // create a BGR mask
-      cv::Mat g_prob = last_mask > 0;
-      cv::Mat g;
-      g_prob.convertTo(g, CV_8U);
+    // If we haven't gotten a neural network inference yet, we can't preview.
+    if (last_mask.empty())
+    {
+        return;
+    }
 
-      cv::Mat r = (1 - g);
-      cv::Mat b(r.size(), CV_8UC1, cv::Scalar(0));
+    // create a BGR mask
+    cv::Mat g_prob = last_mask > 0;
+    cv::Mat g;
+    g_prob.convertTo(g, CV_8U);
 
-      std::vector<cv::Mat> channels{ b, g, r };
-      cv::Mat show_mask;
-      cv::merge(channels, show_mask);
-      show_mask *= 255;
+    cv::Mat r = (1 - g);
+    cv::Mat b(r.size(), CV_8UC1, cv::Scalar(0));
 
-      cv::resize(show_mask, show_mask, frame.size());
+    std::vector<cv::Mat> channels{ b, g, r };
+    cv::Mat show_mask;
+    cv::merge(channels, show_mask);
+    show_mask *= 255;
 
-      // These are blending coefficients for adding the mask
-      // to the image: alpha * image + beta * mask
-      float alpha = 0.8;
-      float beta = 1 - alpha;
+    cv::resize(show_mask, show_mask, frame.size());
 
-      cv::Mat dst;
-      cv::addWeighted(frame, alpha, show_mask, beta, 0.0, dst);
-      dst.copyTo(frame);
+    // These are blending coefficients for adding the mask
+    // to the image: alpha * image + beta * mask
+    float alpha = 0.8;
+    float beta = 1 - alpha;
+
+    cv::Mat dst;
+    cv::addWeighted(frame, alpha, show_mask, beta, 0.0, dst);
+    dst.copyTo(frame);
 }
 
-void BinaryUnetModel::handle_inference_output(const cv::optional<cv::Mat> &out_mask, cv::Mat &last_mask, float threshold)
+void BinaryUnetModel::handle_inference_output(const cv::optional<cv::Mat> &out_mask, const cv::optional<int64_t> &inference_ts, cv::Mat &last_mask, float threshold)
 {
     if (!out_mask.has_value())
     {
         return;
     }
 
+    // This comes from the same branch in the G-API graph as out_mask, and so must have a value if out_mask does.
+    CV_Assert(inference_ts.has_value());
+
     // Create a mask - everywhere that the network has confidence greater than threshold
     cv::Mat mask_vals(*out_mask > threshold);
 
     // Compute the fraction of the image that is occupied by detections
-    float relativeOccupied = static_cast<float>(cv::countNonZero(mask_vals)) / (mask_vals.rows * mask_vals.cols);
+    float relative_occupied = static_cast<float>(cv::countNonZero(mask_vals)) / (mask_vals.rows * mask_vals.cols);
 
     // Create JSON message of the following schema
     //
@@ -210,13 +247,25 @@ void BinaryUnetModel::handle_inference_output(const cv::optional<cv::Mat> &out_m
     // uses a list just to conform.
     std::string str = std::string("[");
     str.append("{")
-        .append("\"occupied\": \"").append(std::to_string(relativeOccupied)).append("\"")
+        .append("\"occupied\": \"").append(std::to_string(relative_occupied)).append("\"")
         .append("}");
     str.append("]");
-    last_mask = std::move(mask_vals);
+
+    // Log this network inference message using adaptive logging, so that we decay its frequency over time
+    // (So we don't end up overwhelming the log files)
     this->log_inference(str);
 
+    // Send this inference message over Azure IoT.
     iot::msgs::send_message(iot::msgs::MsgChannel::NEURAL_NETWORK, str);
+
+    // Now that we have a new inference, let's cache it.
+    last_mask = *out_mask;
+
+    // If we want to time-align our network inferences with camera frames, we need to
+    // do that here (now that we have a new inference to align in time with the frames we've been saving).
+    // The super class will check for us and handle this appropriately.
+    auto f_to_call_on_each_frame = [last_mask, this](cv::Mat &frame){ this->preview(frame, last_mask); };
+    this->handle_new_inference_for_time_alignment(inference_ts, f_to_call_on_each_frame);
 }
 
 void BinaryUnetModel::log_parameters() const

--- a/azureeyemodule/app/model/binaryunet.hpp
+++ b/azureeyemodule/app/model/binaryunet.hpp
@@ -1,5 +1,10 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * This model is for use with the banana-unet-tutorial. It is a simple U-Net for semantic segmentation,
+ * using only one class: bananas!
+ */
 #pragma once
 
 // Standard library includes
@@ -21,31 +26,81 @@ namespace model {
 class BinaryUnetModel : public AzureEyeModel
 {
 public:
+    /**
+     * Constructor.
+     *
+     * @param modelfpaths: In this model, we expect this to be a vector of length 1 (all model constructors take a vector of paths, but most only use 1 model path).
+     *                     Model paths are strings that point to the model .blob files. If you are developing a cascaded model (see ocr for example), you will
+     *                     need to pass a model file for each network in the cascade.
+     * @param mvcmd:       The Myriad X firmware binary. A running model owns the VPU, so it is responsible for initializing it as well.
+     * @param videofile:   If we pass a non-empty string here, the model will record frames to a file at this location as a .mp4.
+     * @param resolution:  The resolution mode to put the camera in.
+     */
     BinaryUnetModel(const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution);
 
+    /** We invoke this method from main to run the network. It should return if there is a model update (found by checking this->restarting). */
     void run(cv::GStreamingCompiled* pipeline) override;
 
 private:
 
-    /** Compile the graph for classification model */
+    /** Compiles the G-API graph. */
     cv::GStreamingCompiled compile_cv_graph() const;
 
-    /** Pull data through the given pipeline. Returns true if we run out of frames, false if we have been interrupted. Otherwise runs forever. */
+    /** Pulls data through the given pipeline. Returns true if we run out of frames, false if we have been interrupted. Otherwise runs forever. */
     bool pull_data(cv::GStreamingCompiled &pipeline);
 
-    /** Update the BGR output to show segmentation. */
-    void handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_bgr, const cv::Mat &last_mask);
+    /**
+     * The G-API graph in this (and most classes) is split into three branches: a branch that handles the H.264 encoding, a branch that
+     * timestamps and forwards the raw camera BGR frames, and a branch that handles the neural network inferences.
+     *
+     * This method handles the outputs from the second branch - the raw BGR branch. It takes the latest BGR frame, updates `last_bgr` to it,
+     * and streams the frame out over the RTSP stream.
+     *
+     * Note that there is an option in the module twin to turn on time alignment. If we do NOT have that option turned on,
+     * we also stream the result frame here after applying last_mask to it.
+     * If we DO have that option turned on, we ignore the marked up frame created by last_mask and instead store
+     * out_bgr (the raw BGR frame) into a buffer for use later, when we have a new neural network inference. At that point,
+     * we search through the buffer of old frames that we have to find the best matching one in time, and then mark up
+     * that frame and all older ones that we have not yet sent to the RTSP server. Then we release all of the marked up frames
+     * in a batch to the RTSP stream (which will churn through them at some specified frames per second rate).
+     *
+     * All of this time alignment stuff is mostly taken care of for you in the super class.
+     *
+     * @param out_bgr: The latest raw BGR frame from the G-API graph. This may be empty (because the graph is asynchronous), in
+     *                 which case we immediately return from this method.
+     * @param bgr_ts: The timestamp of out_bgr.
+     * @param last_bgr: We cache out_bgr into this for use in other methods.
+     * @param last_mask: The latest neural network output mask to use in marking up the RTSP stream if we are not time aligning.
+     */
+    void handle_bgr_output(const cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &bgr_ts, cv::Mat &last_bgr, const cv::Mat &last_mask);
 
-    /** Actually draws segmented output. */
+    /** Draws segmented output onto the given frame using the given mask. */
     void preview(cv::Mat& rgb, const cv::Mat& last_mask) const;
 
-    /** Send the class percentage occupancy message */
-    void handle_inference_output(const cv::optional<cv::Mat> &out_mask,
-                                    cv::Mat &last_mask,
-                                    float threshold = 0.5
-                                    );
+    /**
+     * The G-API graph in this (and most classes) is split into three branches: a branch that handles the H.264 encoding, a branch that
+     * timestamps and forwards the raw camera BGR frames, and a branch that handles the neural network inferences.
+     *
+     * This method handles the third branch - the neural network output branch. Whenever we get a new neural network output,
+     * we handle it by doing two things:
+     *
+     * 1. We compose a JSON message that says what percentage of the image is occupied by the detected object(s).
+     *    Then we send this message out over IoT.
+     * 2. If we are time-aligning frames (see handle_bgr_output's documentation), we alert the super class that we have
+     *    a new inference. The super class will go search through the stored frames for the one most closely aligned in
+     *    time with the frame that this network was working on for this inference, and it marks up all the frames
+     *    from that point backwards, and then releases them to the RTSP server.
+     *
+     * @param out_mask: The latest mask from the G-API graph. This may be empty (because the graph is asynchronous), in which case
+     *                  we immediately return from this method.
+     * @param inference_ts: The timestamp associated with out_mask. I.e., the timestamp of the frame that the neural network was working on
+     *                      to produce this output.
+     * @param last_mask: We cache out_mask into this for use in other methods.
+     * @param threshold: We count detections above this confidence threshold as actual.
+     */
+    void handle_inference_output(const cv::optional<cv::Mat> &out_mask, const cv::optional<int64_t> &inference_ts, cv::Mat &last_mask, float threshold = 0.5);
 
-    /** Print out all the model's meta information. */
+    /** Prints out all the model's meta information for logging purposes. */
     void log_parameters() const;
 };
 

--- a/azureeyemodule/app/model/classification.hpp
+++ b/azureeyemodule/app/model/classification.hpp
@@ -23,8 +23,22 @@ namespace model {
 class ClassificationModel : public AzureEyeModel
 {
 public:
+    /**
+     * Constructor.
+     *
+     * @param labelfpath: Path to a file containing one label per line. The labels should correspond to the class index
+     *                    such that the first line should contain the label for the first class index.
+     * @param modelfpaths: In this model, we expect this to be a vector of length 1 (all model constructors take a vector of paths, but most only use 1 model path).
+     *                     Model paths are strings that point to the model .blob files. If you are developing a cascaded model (see ocr for example), you will
+     *                     need to pass a model file for each network in the cascade.
+     * @param mvcmd:       The Myriad X firmware binary. A running model owns the VPU, so it is responsible for initializing it as well.
+     * @param videofile:   If we pass a non-empty string here, the model will record frames to a file at this location as a .mp4.
+     * @param resolution:  The resolution mode to put the camera in.
+
+     */
     ClassificationModel(const std::string &labelfpath, const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution);
 
+    /** We invoke this method from main to run the network. It should return if there is a model update (found by checking this->restarting). */
     void run(cv::GStreamingCompiled* pipeline) override;
 
 private:
@@ -34,23 +48,67 @@ private:
     /** Labels for the things we classify. */
     std::vector<std::string> class_labels;
 
-    /** Compile the graph for classification model */
+    /** Compiles the G-API graph for this model. */
     cv::GStreamingCompiled compile_cv_graph() const;
 
-    /** Pull data through the given pipeline. Returns true if we run out of frames, false if we have been interrupted. Otherwise runs forever. */
+    /** Pulls data through the given pipeline. Returns true if we run out of frames, false if we have been interrupted. Otherwise runs forever. */
     bool pull_data(cv::GStreamingCompiled &pipeline);
 
-    /** Update the BGR output to show the labels. */
-    void handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_bgr, const std::vector<int> &last_labels, const std::vector<float> &last_confidences);
+    /**
+     * The G-API graph in this (and most classes) is split into three branches: a branch that handles the H.264 encoding, a branch that
+     * timestamps and forwards the raw camera BGR frames, and a branch that handles the neural network inferences.
+     *
+     * This method handles the outputs from the second branch - the raw BGR branch. It takes the latest BGR frame, updates `last_bgr` to it,
+     * and streams the frame out over the RTSP stream.
+     *
+     * Note that there is an option in the module twin to turn on time alignment. If we do NOT have that option turned on,
+     * we also stream the result frame here after applying last_labels and last_confidences to it.
+     * If we DO have that option turned on, we ignore the marked up frame created by last_mask and instead store
+     * out_bgr (the raw BGR frame) into a buffer for use later, when we have a new neural network inference. At that point,
+     * we search through the buffer of old frames that we have to find the best matching one in time, and then mark up
+     * that frame and all older ones that we have not yet sent to the RTSP server. Then we release all of the marked up frames
+     * in a batch to the RTSP stream (which will churn through them at some specified frames per second rate).
+     *
+     * All of this time alignment stuff is mostly taken care of for you in the super class.
+     *
+     * @param out_bgr: The latest raw BGR frame from the G-API graph. This may be empty (because the graph is asynchronous), in
+     *                 which case we immediately return from this method.
+     * @param bgr_ts: The timestamp of out_bgr.
+     * @param last_bgr: We cache out_bgr into this for use in other methods.
+     * @param last_labels: The latest neural network output label(s) to use in marking up the RTSP stream if we are not time aligning.
+     * @param last_confidences: The latest neural network output confidence(s) to use in marking up the RTSP stream if we are not time aligning.
+     */
+    void handle_bgr_output(cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &bgr_ts, cv::Mat &last_bgr,
+                           const std::vector<int> &last_labels, const std::vector<float> &last_confidences);
 
-    /** Compose the RGB based on the labels. */
+    /** Marks up the given rgb with the given labels and confidences. */
     void preview(const cv::Mat& rgb, const std::vector<int>& labels, const std::vector<float>& confidences) const;
 
-    /** Handle the detector's output */
+    /**
+     * The G-API graph in this (and most classes) is split into three branches: a branch that handles the H.264 encoding, a branch that
+     * timestamps and forwards the raw camera BGR frames, and a branch that handles the neural network inferences.
+     *
+     * This method handles the third branch - the neural network output branch. Whenever we get a new neural network output,
+     * we handle it by doing two things:
+     *
+     * 1. We compose a JSON message that says what objects are detected and with what confidences.
+     *    Then we send this message out over IoT.
+     * 2. If we are time-aligning frames (see handle_bgr_output's documentation), we alert the super class that we have
+     *    a new inference. The super class will go search through the stored frames for the one most closely aligned in
+     *    time with the frame that this network was working on for this inference, and it marks up all the frames
+     *    from that point backwards, and then releases them to the RTSP server.
+     *
+     * @param out_nn_ts: The timestamp associated with out_labels and out_confidences.
+     * @param out_nn_seqno: The frame number of the frame that the network was working on to produce this output.
+     * @param out_labels: The latest neural network output labels.
+     * @param out_confidences: The latest neural network output confidences.
+     * @param last_labels: We cache the labels into this for use in other methods.
+     * @param last_confidences: We cache the confidences into this for use in other methods.
+     */
     void handle_inference_output(const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
-                                                      const cv::optional<std::vector<int>> &out_labels,
-                                                      const cv::optional<std::vector<float>> &out_confidences, std::vector<int> &last_labels,
-                                                      std::vector<float> &last_confidences);
+                                 const cv::optional<std::vector<int>> &out_labels,
+                                 const cv::optional<std::vector<float>> &out_confidences, std::vector<int> &last_labels,
+                                 std::vector<float> &last_confidences);
 
     /** Print out all the model's meta information. */
     void log_parameters() const;

--- a/azureeyemodule/app/model/fasterrcnn.cpp
+++ b/azureeyemodule/app/model/fasterrcnn.cpp
@@ -25,8 +25,11 @@ namespace model {
 
 /**
  * The Faster RCNN network takes two inputs: the image, which will be cropped and downsampled down to 600x1024,
- * and some information about the image, shaped [1, 3], where the first item is batch size and the last item
+ * and some information about the image, shaped {1, 3}, where the first item is batch size and the last item
  * is a vector of three values: height, width, scale-factor (1).
+ *
+ * However, the second input is a constant input, and so is handled in a special way by the G-API. See the
+ * G-API graph construction for further details.
  *
  * The Faster RCNN network outputs a single output, which we will parse into boxes, labels, and confidences.
  */
@@ -42,6 +45,7 @@ void FasterRCNNModel::run(cv::GStreamingCompiled* pipeline)
 {
     while (true)
     {
+        // Wait for the VPU to come up.
         this->wait_for_device();
 
         // Read in the labels for classification
@@ -65,60 +69,74 @@ void FasterRCNNModel::run(cv::GStreamingCompiled* pipeline)
 
 cv::GStreamingCompiled FasterRCNNModel::compile_cv_graph() const
 {
+    // The input node of the G-API pipeline. This will be filled in, one frame at time.
     cv::GMat in;
+
+    // We have a custom preprocessing node for the Myriad X-attached camera.
     cv::GMat preproc = cv::gapi::mx::preproc(in, this->resolution);
+
+    // This path is the H.264 path. It gets our frames one at a time from
+    // the camera and encodes them into H.264.
     cv::GArray<uint8_t> h264;
     cv::GOpaque<int64_t> h264_seqno;
     cv::GOpaque<int64_t> h264_ts;
     std::tie(h264, h264_seqno, h264_ts) = cv::gapi::streaming::encH264ts(preproc);
 
-    // We have BGR output and H264 output in the same graph.
-    // In this case, BGR always must be desynchronized from the main path
-    // to avoid internal queue overflow (FW reports this data to us via
-    // separate channels)
-    // copy() is required only to maintain the graph contracts
-    // (there must be an operation following desync()). No real copy happens
+    // We branch off from the preproc node into H.264 (above), raw BGR output (here),
+    // and neural network inferences (below).
     cv::GMat img = cv::gapi::copy(cv::gapi::streaming::desync(preproc));
+    cv::GOpaque<int64_t> img_ts = cv::gapi::streaming::timestamp(img);
 
-    // This branch has inference and is desynchronized to keep
-    // a constant framerate for the encoded stream (above)
+    // This node branches off from the preproc node for neural network inferencing.
     cv::GMat bgr = cv::gapi::streaming::desync(preproc);
+    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(bgr);
 
+    // Here's where we actually run our neural network. It runs on the VPU.
     cv::GMat nn = cv::gapi::infer<FasterRCNNNetwork>(bgr);
 
+    // Grab some useful information: the frame number, the timestamp, and the size of the frame.
     cv::GOpaque<int64_t> nn_seqno = cv::gapi::streaming::seqNo(nn);
-    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(nn);
     cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(bgr);
 
+    // Faster RCNN can use the exact same parser as SSD, so we reuse the code.
+    // We output the bounding boxes, class IDs, and confidence scores.
     cv::GArray<cv::Rect> rcs;
     cv::GArray<int> ids;
     cv::GArray<float> cfs;
-
-    // Faster RCNN can use the exact same parser as SSD
     std::tie(rcs, ids, cfs) = cv::gapi::streaming::parseSSDWithConf(nn, sz);
 
-    // Now specify the computation's boundaries
+    // Specify the boundaries of the G-API graph (the inputs and outputs).
     auto graph = cv::GComputation(cv::GIn(in),
-                                  cv::GOut(h264, h264_seqno, h264_ts,      // main path: H264 (~constant framerate)
-                                  img,                                     // desynchronized path: BGR
-                                  nn_seqno, nn_ts, rcs, ids, cfs, sz));    // Inference path
+                                  cv::GOut(h264, h264_seqno, h264_ts,               // H.264 branch
+                                           img, img_ts,                             // Raw BGR frame branch
+                                           nn_seqno, nn_ts, rcs, ids, cfs, sz));    // Inference branch
 
+    // Pass the actual neural network blob file into the graph. We assume we have a modelfiles of length at least 1.
+    CV_Assert(this->modelfiles.size() >= 1);
     auto detector = cv::gapi::mx::Params<FasterRCNNNetwork>{this->modelfiles.at(0)};
 
-    // Faster RCNN requires this constant input thing
+    // The particular model we support for Faster RCNN requires two inputs: the raw image,
+    // and some metadata, which is constant over the course of the network's lifetime.
+    // When you have a constant input to a neural network, the G-API allows you to specify
+    // it like this.
     cv::Mat constant_imginfo(cv::Size{3, 1}, CV_32FC1);
     auto ptr = constant_imginfo.ptr<float>();
     ptr[0] = 600;
     ptr[1] = 1024;
     ptr[2] = 1;
     detector.constInput("image_info", constant_imginfo);
+
+    // Now configure the input layers to be the only one that we actually feed in the graph.
+    // The other one is now specified as a constant input and is no longer considered an "input layer".
     detector.cfgInputLayers({"image_tensor"});
 
+    // Wrap up the configured network into a GNetPackage class.
     auto networks = cv::gapi::networks(detector);
 
+    // Here we wrap up all the kernels (the implementations of the G-API ops) that we need for our graph.
     auto kernels = cv::gapi::combine(cv::gapi::mx::kernels(), cv::gapi::kernels<cv::gapi::streaming::GOCVParseSSDWithConf>());
 
-    // Compile the graph in streamnig mode, set all the parameters
+    // Compile the graph in streamnig mode; set all the parameters; feed the firmware file into the VPU.
     auto pipeline = graph.compileStreaming(cv::gapi::mx::Camera::params(), cv::compile_args(networks, kernels, cv::gapi::mx::mvcmdFile{ this->mvcmd }));
 
     // Specify the Azure Percept's Camera as the input to the pipeline, and start processing

--- a/azureeyemodule/app/model/fasterrcnn.hpp
+++ b/azureeyemodule/app/model/fasterrcnn.hpp
@@ -20,16 +20,32 @@ namespace model {
 
 /**
  * A class to represent a Faster RCNN model for the Azure Percept device.
+ *
+ * Since Faster RCNN is a type of object detection model, we subclass off
+ * of ObjectDetector (which itself subclasses off of AzureEyeModel).
  */
 class FasterRCNNModel : public ObjectDetector
 {
 public:
+    /**
+     * Constructor.
+     *
+     * @param labelfpath: Path to a file containing one label per line. The labels should correspond to the class index
+     *                    such that the first line should contain the label for the first class index.
+     * @param modelfpaths: In this model, we expect this to be a vector of length 1 (all model constructors take a vector of paths, but most only use 1 model path).
+     *                     Model paths are strings that point to the model .blob files. If you are developing a cascaded model (see ocr for example), you will
+     *                     need to pass a model file for each network in the cascade.
+     * @param mvcmd:       The Myriad X firmware binary. A running model owns the VPU, so it is responsible for initializing it as well.
+     * @param videofile:   If we pass a non-empty string here, the model will record frames to a file at this location as a .mp4.
+     * @param resolution:  The resolution mode to put the camera in.
+     */
     FasterRCNNModel(const std::string &labelfpath, const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution);
 
+    /** We invoke this method from main to run the network. It should return if there is a model update (found by checking this->restarting). */
     void run(cv::GStreamingCompiled* pipeline) override;
 
 private:
-    /** Compile the pipeline graph for Faster RCNN. */
+    /** Compiles the G-API graph for Faster RCNN .*/
     cv::GStreamingCompiled compile_cv_graph() const;
 
     /** Print out all the model's meta information. */

--- a/azureeyemodule/app/model/objectdetector.cpp
+++ b/azureeyemodule/app/model/objectdetector.cpp
@@ -3,6 +3,7 @@
 
 // Standard library includes
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <sstream>
 #include <string>
@@ -33,70 +34,73 @@ ObjectDetector::~ObjectDetector()
 {
 }
 
-void ObjectDetector::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_bgr, const std::vector<cv::Rect> &last_boxes,
-                                       const std::vector<int> &last_labels, const std::vector<float> &last_confidences)
+bool ObjectDetector::pull_data(cv::GStreamingCompiled &pipeline)
 {
-    // BGR output: visualize and optionally display
-    if (!out_bgr.has_value())
+    // All of our object detector models have the same graph outputs.
+
+    // These are the nodes from the raw camera frame path.
+    cv::optional<cv::Mat> out_bgr;
+    cv::optional<int64_t> out_bgr_ts;
+
+    // These are the nodes from the H.264 path.
+    cv::optional<std::vector<uint8_t>> out_h264;
+    cv::optional<int64_t> out_h264_seqno;
+    cv::optional<int64_t> out_h264_ts;
+
+    // These are th enodes from the neural network inference path.
+    cv::optional<cv::Mat> out_nn;
+    cv::optional<int64_t> out_nn_ts;
+    cv::optional<int64_t> out_nn_seqno;
+    cv::optional<std::vector<cv::Rect>> out_boxes;
+    cv::optional<std::vector<int>> out_labels;
+    cv::optional<std::vector<float>> out_confidences;
+    cv::optional<cv::Size> out_size;
+
+    // These are the values that we cache (since the graph is asynchronous).
+    std::vector<cv::Rect> last_boxes;
+    std::vector<int> last_labels;
+    std::vector<float> last_confidences;
+    cv::Mat last_bgr;
+
+    // If the user wants to record a video, we open the video file.
+    std::ofstream ofs;
+    if (!this->videofile.empty())
     {
-        return;
+        ofs.open(this->videofile, std::ofstream::out | std::ofstream::binary | std::ofstream::trunc);
     }
 
-    last_bgr = *out_bgr;
-
-    cv::Mat original_bgr;
-    last_bgr.copyTo(original_bgr);
-
-    rtsp::update_data_raw(last_bgr);
-    preview(last_bgr, last_boxes, last_labels, last_confidences);
-
-    if (this->status_msg.empty())
+    // Pull the data from the pipeline while it is running
+    // Every time we call pull(), G-API gives us whatever nodes it has ready.
+    // So we have to make sure a node has useful contents before using it.
+    while (pipeline.pull(cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_bgr_ts, out_nn_seqno, out_nn_ts, out_boxes, out_labels, out_confidences, out_size)))
     {
-        rtsp::update_data_result(last_bgr);
-    }
-    else
-    {
-        cv::Mat bgr_with_status;
-        last_bgr.copyTo(bgr_with_status);
+        this->handle_h264_output(out_h264, out_h264_ts, out_h264_seqno, ofs);
+        this->handle_inference_output(out_nn_ts, out_nn_seqno, out_boxes, out_labels, out_confidences, out_size, last_boxes, last_labels, last_confidences);
+        this->handle_bgr_output(out_bgr, out_bgr_ts, last_bgr, last_boxes, last_labels, last_confidences);
 
-        util::put_text(bgr_with_status, this->status_msg);
-        rtsp::update_data_result(bgr_with_status);
+        if (this->restarting)
+        {
+            // We've been interrupted
+            this->cleanup(pipeline, last_bgr);
+            return false;
+        }
     }
 
-    // Maybe save and export the retraining data at this point
-    this->save_retraining_data(original_bgr, last_confidences);
+    // Ran out of frames
+    return true;
 }
 
-void ObjectDetector::preview(const cv::Mat& rgb, const std::vector<cv::Rect>& boxes, const std::vector<int>& labels, const std::vector<float>& confidences) const
-{
-    for (std::size_t i = 0; i < boxes.size(); i++)
-    {
-        // color of a label
-        int index = labels[i] % label::colors().size();
-
-        cv::rectangle(rgb, boxes[i], label::colors().at(index), 2);
-        cv::putText(rgb,
-            util::get_label(labels[i], this->class_labels) + ": " + util::to_string_with_precision(confidences[i], 2),
-            boxes[i].tl() + cv::Point(3, 20),
-            cv::FONT_HERSHEY_SIMPLEX,
-            0.7,
-            cv::Scalar(label::colors().at(index)),
-            2);
-    }
-}
-
-void ObjectDetector::handle_inference_output(const cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
-                                              const cv::optional<std::vector<cv::Rect>> &out_boxes, const cv::optional<std::vector<int>> &out_labels,
-                                              const cv::optional<std::vector<float>> &out_confidences, const cv::optional<cv::Size> &out_size, std::vector<cv::Rect> &last_boxes, std::vector<int> &last_labels,
-                                              std::vector<float> &last_confidences)
+void ObjectDetector::handle_inference_output(const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
+                                             const cv::optional<std::vector<cv::Rect>> &out_boxes, const cv::optional<std::vector<int>> &out_labels,
+                                             const cv::optional<std::vector<float>> &out_confidences, const cv::optional<cv::Size> &out_size, std::vector<cv::Rect> &last_boxes, std::vector<int> &last_labels,
+                                             std::vector<float> &last_confidences)
 {
     if (!out_nn_ts.has_value())
     {
         return;
     }
 
-    // The below objects are on the same desynchronized path
-    // and are coming together
+    // These nodes are all on the same branch of the G-API graph, so they should all be arriving together.
     CV_Assert(out_nn_ts.has_value());
     CV_Assert(out_nn_seqno.has_value());
     CV_Assert(out_boxes.has_value());
@@ -157,6 +161,7 @@ void ObjectDetector::handle_inference_output(const cv::optional<cv::Mat> &out_bg
     }
     str.append("]");
 
+    // Log the neural network inference using a special decaying filter so we don't bloat our log files.
     this->log_inference("nn: seqno=" + std::to_string(*out_nn_seqno) + ", ts=" + std::to_string(*out_nn_ts) + ", " + str);
 
     // Send out the detection message to anyone who's listening (this will add curly braces around the inference message)
@@ -166,52 +171,66 @@ void ObjectDetector::handle_inference_output(const cv::optional<cv::Mat> &out_bg
     last_boxes = std::move(*out_boxes);
     last_labels = std::move(*out_labels);
     last_confidences = std::move(*out_confidences);
+
+    // If we want to time-align our network inferences with camera frames, we need to
+    // do that here (now that we have a new inference to align in time with the frames we've been saving).
+    // The super class will check for us and handle this appropriately.
+    #ifdef DEBUG_TIME_ALIGNMENT
+        util::log_debug("Sending a new inference to time algo.");
+    #endif
+    auto f_to_call_on_each_frame = [last_boxes, last_labels, last_confidences, this](cv::Mat &frame){ this->preview(frame, last_boxes, last_labels, last_confidences); };
+    this->handle_new_inference_for_time_alignment(*out_nn_ts, f_to_call_on_each_frame);
 }
 
-bool ObjectDetector::pull_data(cv::GStreamingCompiled &pipeline)
+void ObjectDetector::preview(cv::Mat &rgb, const std::vector<cv::Rect> &boxes, const std::vector<int> &labels, const std::vector<float> &confidences) const
 {
-    cv::optional<cv::Mat> out_bgr;
-
-    cv::optional<std::vector<uint8_t>> out_h264;
-    cv::optional<int64_t> out_h264_seqno;
-    cv::optional<int64_t> out_h264_ts;
-
-    cv::optional<cv::Mat> out_nn;
-    cv::optional<int64_t> out_nn_ts;
-    cv::optional<int64_t> out_nn_seqno;
-    cv::optional<std::vector<cv::Rect>> out_boxes;
-    cv::optional<std::vector<int>> out_labels;
-    cv::optional<std::vector<float>> out_confidences;
-    cv::optional<cv::Size> out_size;
-
-    std::vector<cv::Rect> last_boxes;
-    std::vector<int> last_labels;
-    std::vector<float> last_confidences;
-    cv::Mat last_bgr;
-
-    std::ofstream ofs;
-    if (!this->videofile.empty())
+    // This method is responsible for marking up the raw BGR frames with the inferences from the
+    // neural network. Since all of our object detector networks output bounding boxes, labels, and confidences,
+    // let's mark up the frames with those items.
+    for (std::size_t i = 0; i < boxes.size(); i++)
     {
-        ofs.open(this->videofile, std::ofstream::out | std::ofstream::binary | std::ofstream::trunc);
+        // Draw a bounding box around the detected object. Use a new color each time
+        // up to some point, at which point we wrap around and start reusing colors.
+        int color_index = labels[i] % label::colors().size();
+        cv::rectangle(rgb, boxes[i], label::colors().at(color_index), 2);
+
+        // Draw the label. Use the same color. If we can't figure out the label
+        // (because the network output something unexpected, or there is no labels file),
+        // we just use the class index.
+        auto label = util::get_label(labels[i], this->class_labels) + ": " + util::to_string_with_precision(confidences[i], 2);
+        auto origin = boxes[i].tl() + cv::Point(3, 20);
+        auto font = cv::FONT_HERSHEY_SIMPLEX;
+        auto fontscale = 0.7;
+        auto color = cv::Scalar(label::colors().at(color_index));
+        auto thickness = 2;
+        cv::putText(rgb, label, origin, font, fontscale, color, thickness);
+    }
+}
+
+void ObjectDetector::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &out_bgr_ts, cv::Mat &last_bgr, const std::vector<cv::Rect> &last_boxes,
+                                       const std::vector<int> &last_labels, const std::vector<float> &last_confidences)
+{
+    if (!out_bgr.has_value())
+    {
+        return;
     }
 
-    // Pull the data from the pipeline while it is running
-    while (pipeline.pull(cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_nn_seqno, out_nn_ts, out_boxes, out_labels, out_confidences, out_size)))
-    {
-        this->handle_h264_output(out_h264, out_h264_ts, out_h264_seqno, ofs);
-        this->handle_inference_output(out_bgr, out_nn_ts, out_nn_seqno, out_boxes, out_labels, out_confidences, out_size, last_boxes, last_labels, last_confidences);
-        this->handle_bgr_output(out_bgr, last_bgr, last_boxes, last_labels, last_confidences);
+    // This branch of the G-API graph contains these things that are all coming together as one bunch.
+    CV_Assert(out_bgr_ts.has_value());
 
-        if (this->restarting)
-        {
-            // We've been interrupted
-            this->cleanup(pipeline, last_bgr);
-            return false;
-        }
-    }
+    // Now that we got a useful value, let's cache it for later.
+    last_bgr = *out_bgr;
 
-    // Ran out of frames
-    return true;
+    // Mark up this frame with our preview function.
+    cv::Mat marked_up_bgr;
+    last_bgr.copyTo(marked_up_bgr);
+    this->preview(marked_up_bgr, last_boxes, last_labels, last_confidences);
+
+    // Stream the latest BGR frame.
+    this->stream_frames(last_bgr, marked_up_bgr, *out_bgr_ts);
+
+    // Maybe save and export the retraining data at this point
+    this->save_retraining_data(last_bgr, last_confidences);
 }
 
 } // namespace model

--- a/azureeyemodule/app/model/objectdetector.hpp
+++ b/azureeyemodule/app/model/objectdetector.hpp
@@ -36,21 +36,68 @@ protected:
     /** Labels for the things we classify. */
     std::vector<std::string> class_labels;
 
-    /** Update the BGR output to show the bounding boxes and labels. */
-    virtual void handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_bgr, const std::vector<cv::Rect> &last_boxes, const std::vector<int> &last_labels, const std::vector<float> &last_confidences);
+    /**
+     * The G-API graph in the object detector subclasses is split into three branches: a branch that handles the H.264 encoding, a branch that
+     * timestamps and forwards the raw camera BGR frames, and a branch that handles the neural network inferences.
+     *
+     * This method handles the outputs from the second branch - the raw BGR branch. It takes the latest BGR frame, updates `last_bgr` to it,
+     * and streams the frame out over the RTSP stream.
+     *
+     * Note that there is an option in the module twin to turn on time alignment. If we do NOT have that option turned on,
+     * we also stream the result frame here after applying last_labels and last_confidences to it.
+     * If we DO have that option turned on, we ignore the marked up frame created by last_mask and instead store
+     * out_bgr (the raw BGR frame) into a buffer for use later, when we have a new neural network inference. At that point,
+     * we search through the buffer of old frames that we have to find the best matching one in time, and then mark up
+     * that frame and all older ones that we have not yet sent to the RTSP server. Then we release all of the marked up frames
+     * in a batch to the RTSP stream (which will churn through them at some specified frames per second rate).
+     *
+     * All of this time alignment stuff is mostly taken care of for you in the super class.
+     *
+     * @param out_bgr: The latest raw BGR frame from the G-API graph. This may be empty (because the graph is asynchronous), in
+     *                 which case we immediately return from this method.
+     * @param out_bgr_ts: The timestamp of out_bgr.
+     * @param last_bgr: We cache out_bgr into this for use in other methods.
+     * @param last_boxes: The latest neural network output bounding box(es) to use in marking up the RTSP stream if we are not time aligning.
+     * @param last_labels: The latest neural network output label(s) to use in marking up the RTSP stream if we are not time aligning.
+     * @param last_confidences: The latest neural network output confidence(s) to use in marking up the RTSP stream if we are not time aligning.
+     */
+    virtual void handle_bgr_output(cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &out_bgr_ts, cv::Mat &last_bgr, const std::vector<cv::Rect> &last_boxes, const std::vector<int> &last_labels, const std::vector<float> &last_confidences);
 
-    /** Handle the detector's output */
-    virtual void handle_inference_output(const cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
+    /**
+     * The G-API graph in the object detection subclasses is split into three branches: a branch that handles the H.264 encoding, a branch that
+     * timestamps and forwards the raw camera BGR frames, and a branch that handles the neural network inferences.
+     *
+     * This method handles the third branch - the neural network output branch. Whenever we get a new neural network output,
+     * we handle it by doing two things:
+     *
+     * 1. We compose a JSON message that says what objects are detected, where, and with what confidences.
+     *    Then we send this message out over IoT.
+     * 2. If we are time-aligning frames (see handle_bgr_output's documentation), we alert the super class that we have
+     *    a new inference. The super class will go search through the stored frames for the one most closely aligned in
+     *    time with the frame that this network was working on for this inference, and it marks up all the frames
+     *    from that point backwards, and then releases them to the RTSP server.
+     *
+     * @param out_nn_ts: The timestamp associated with out_boxes, out_labels, and out_confidences.
+     * @param out_nn_seqno: The frame number of the frame that the network was working on to produce this output.
+     * @param out_boxes: The latest neural network output bounding boxes.
+     * @param out_labels: The latest neural network output labels.
+     * @param out_confidences: The latest neural network output confidences.
+     * @param out_size: The size of the RGB frame. We need this for converting the coordinates from normalized to absolute.
+     * @param last_boxes: We cache the bounding boxes into this for use in other methods.
+     * @param last_labels: We cache the labels into this for use in other methods.
+     * @param last_confidences: We cache the confidences into this for use in other methods.
+     */
+    virtual void handle_inference_output(const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
                                          const cv::optional<std::vector<cv::Rect>> &out_boxes, const cv::optional<std::vector<int>> &out_labels,
-                                         const cv::optional<std::vector<float>> &out_confidences, const cv::optional<cv::Size> &out_size, std::vector<cv::Rect> &last_boxes, std::vector<int> &last_labels,
-                                         std::vector<float> &last_confidences);
+                                         const cv::optional<std::vector<float>> &out_confidences, const cv::optional<cv::Size> &out_size,
+                                         std::vector<cv::Rect> &last_boxes, std::vector<int> &last_labels, std::vector<float> &last_confidences);
 
     /** Pull data through the given pipeline. Returns true if we run out of frames, false if we have been interrupted. Otherwise runs forever. */
     virtual bool pull_data(cv::GStreamingCompiled &pipeline);
 
 private:
-    /** Compose the RGB based on the labels and boxes. */
-    void preview(const cv::Mat &rgb, const std::vector<cv::Rect> &boxes, const std::vector<int> &labels, const std::vector<float> &confidences) const;
+    /** Marks up the given rgb with the given labels, bounding boxes, and confidences. */
+    void preview(cv::Mat &rgb, const std::vector<cv::Rect> &boxes, const std::vector<int> &labels, const std::vector<float> &confidences) const;
 };
 
 } // namespace model

--- a/azureeyemodule/app/model/ocr.cpp
+++ b/azureeyemodule/app/model/ocr.cpp
@@ -30,22 +30,24 @@
 
 namespace model {
 
+// Our Text Detection model takes in a frame and outputs two tensors. The recognition model takes in a single tensor and outputs another.
 using GMat2 = std::tuple<cv::GMat, cv::GMat>;
 G_API_NET(TextDetection, <GMat2(cv::GMat)>, "sample.custom.text_detect");
 G_API_NET(TextRecognition, <cv::GMat(cv::GMat)>,"sample.custom.text_recogn");
 
 OCRModel::OCRModel(const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution)
         :AzureEyeModel{ modelfpaths, mvcmd, videofile, resolution }, OCRDecoder(ocr::TextDecoder {0, "0123456789abcdefghijklmnopqrstuvwxyz#", '#'})
-        {
-        }
+{
+}
 
 void OCRModel::run(cv::GStreamingCompiled* pipeline)
 {
     while(true)
     {
-
+        // Wait for the VPU to come up.
         this->wait_for_device();
 
+        // Log our meta data.
         this->log_parameters();
 
         // Build the camera pipeline with G-API
@@ -55,7 +57,6 @@ void OCRModel::run(cv::GStreamingCompiled* pipeline)
 
         // Pull data through the pipeline
         bool ran_out_naturally = this->pull_data(*pipeline);
-
         if (!ran_out_naturally)
         {
             break;
@@ -65,58 +66,66 @@ void OCRModel::run(cv::GStreamingCompiled* pipeline)
 
 cv::GStreamingCompiled OCRModel::compile_cv_graph() const
 {
-    // Declare an empty GMat - the beginning of the pipeline
+    // The input node of the G-API pipeline. This will be filled in, one frame at time.
     cv::GMat in;
+
+    // We have a custom preprocessing node for the Myriad X-attached camera.
     cv::GMat preproc = cv::gapi::mx::preproc(in, this->resolution);
+
+    // This path is the H.264 path. It gets our frames one at a time from
+    // the camera and encodes them into H.264.
     cv::GArray<uint8_t> h264;
     cv::GOpaque<int64_t> h264_seqno;
     cv::GOpaque<int64_t> h264_ts;
     std::tie(h264, h264_seqno, h264_ts) = cv::gapi::streaming::encH264ts(preproc);
 
-    // We have BGR output and H264 output in the same graph.
-    // In this case, BGR always must be desynchronized from the main path
-    // to avoid internal queue overflow (FW reports this data to us via
-    // separate channels)
-    // copy() is required only to maintain the graph contracts
-    // (there must be an operation following desync()). No real copy happens
+    // We branch off from the preproc node into H.264 (above), raw BGR output (here),
+    // and neural network inferences (below).
     cv::GMat img = cv::gapi::copy(cv::gapi::streaming::desync(preproc));
+    auto img_ts = cv::gapi::streaming::timestamp(img);
 
-    // TODO: remove copy
-
-    // This branch has inference and is desynchronized to keep
-    // a constant framerate for the encoded stream (above)
+    // This node branches off from the preproc node for neural network inferencing.
     cv::GMat bgr = cv::gapi::streaming::desync(preproc);
+    auto nn_ts = cv::gapi::streaming::timestamp(bgr);
 
-     // Text recognition input size
+    // Text recognition input size
     cv::Size in_rec_sz{ 120, 32 };
 
+    // The first network (the text detector) outputs two tensors: link and sgm
     cv::GMat link, segm;
     std::tie(link, segm) = cv::gapi::infer<TextDetection>(bgr);
+
+    // Here we post-process the outputs of the text detection network
     cv::GOpaque<cv::Size> size = cv::gapi::streaming::size(bgr);
     cv::GArray<cv::RotatedRect> rrs = cv::gapi::streaming::PostProcess::on(link, segm, size, 0.8f, 0.8f);
     cv::GArray<cv::GMat> td_labels = cv::gapi::streaming::CropLabels::on(bgr, rrs, in_rec_sz);
-    cv::GArray<cv::GMat> text = cv::gapi::infer2<TextRecognition>(bgr, td_labels);
 
-    cv::GOpaque<int64_t> nn_seqno = cv::gapi::streaming::seqNo(link);
-    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(link);
+    // Now we feed the post-processed output into the text recognition RNN
+    cv::GArray<cv::GMat> text = cv::gapi::infer2<TextRecognition>(bgr, td_labels);
 
 
     // Now specify the computation's boundaries
     auto graph = cv::GComputation(cv::GIn(in),
-                                  cv::GOut(h264, h264_seqno, h264_ts,      // main path: H264 (~constant framerate)
-                                  img,                                     // desynchronized path: BGR
-                                  nn_seqno, nn_ts, rrs, text));
+                                  cv::GOut(h264, h264_seqno, h264_ts,   // The H.264 branch of the graph
+                                           img, img_ts,                 // The raw BGR frame branch
+                                           nn_ts, rrs, text));          // The neural network branch
 
+    // There are two output layers from the text detection network. Specify them here. Also pass in the model file for the first network.
     auto textdetection_net = cv::gapi::mx::Params<TextDetection> {modelfiles.at(0)}.cfgOutputLayers({"model/link_logits_/add", "model/segm_logits/add"});
+
+    // Feed in the model file for the second network.
     auto textrecognition_net = cv::gapi::mx::Params<TextRecognition> {modelfiles.at(1)};
+
+    // Wrap up the networks.
     auto networks = cv::gapi::networks(textdetection_net, textrecognition_net);
 
+    // Wrap up the kernels.
     auto kernels = cv::gapi::combine(cv::gapi::mx::kernels(), cv::gapi::kernels<cv::gapi::streaming::OCVPostProcess>(), cv::gapi::kernels<cv::gapi::streaming::OCVCropLabels>());
 
-    // Compile the graph in streamnig mode, set all the parameters
+    // Compile the graph in streamnig mode, set all the parameters.
     auto pipeline = graph.compileStreaming(cv::gapi::mx::Camera::params(), cv::compile_args(networks, kernels, cv::gapi::mx::mvcmdFile{ this->mvcmd }));
 
-    // Specify the Azure Percept's Camera as the input to the pipeline, and start processing
+    // Specify the Azure Percept's Camera as the input to the pipeline.
     pipeline.setSource(cv::gapi::wip::make_src<cv::gapi::mx::Camera>());
 
     return pipeline;
@@ -124,21 +133,26 @@ cv::GStreamingCompiled OCRModel::compile_cv_graph() const
 
 bool OCRModel::pull_data(cv::GStreamingCompiled &pipeline)
 {
+    // The raw BGR frames from the camera will fill this node.
     cv::optional<cv::Mat> out_bgr;
+    cv::optional<int64_t> out_bgr_ts;
 
+    // The H.264 outputs will fill these nodes.
     cv::optional<std::vector<uint8_t>> out_h264;
     cv::optional<int64_t> out_h264_seqno;
     cv::optional<int64_t> out_h264_ts;
 
+    // The neural network branch outputs will fill these nodes.
     cv::optional<int64_t> out_nn_ts;
-    cv::optional<int64_t> out_nn_seqno;
     cv::optional<std::vector<cv::RotatedRect>> out_txtrcs;
     cv::optional<std::vector<cv::Mat>> out_text;
 
+    // We cache our latest results in these variables, since they are coming at different times.
     cv::Mat last_bgr;
     std::vector<cv::RotatedRect> last_rcs;
     std::vector<std::string> last_text;
 
+    // If the user wants to record a video, we open the video file.
     std::ofstream ofs;
     if (!this->videofile.empty())
     {
@@ -146,11 +160,11 @@ bool OCRModel::pull_data(cv::GStreamingCompiled &pipeline)
     }
 
     // Pull the data from the pipeline while it is running
-    while (pipeline.pull( cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_nn_seqno, out_nn_ts, out_txtrcs, out_text)))
+    while (pipeline.pull(cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_bgr_ts, out_nn_ts, out_txtrcs, out_text)))
     {
         this->handle_h264_output(out_h264, out_h264_ts, out_h264_seqno, ofs);
-		this->handle_bgr_output(out_bgr, last_bgr, last_rcs, last_text);
-        this->handle_inference_output(out_nn_ts, out_nn_seqno, out_txtrcs, last_rcs, out_text, last_text);
+        this->handle_inference_output(out_nn_ts, out_txtrcs, last_rcs, out_text, last_text);
+        this->handle_bgr_output(out_bgr, out_bgr_ts, last_bgr, last_rcs, last_text);
 
         if (this->restarting)
         {
@@ -164,71 +178,57 @@ bool OCRModel::pull_data(cv::GStreamingCompiled &pipeline)
     return true;
 }
 
-void OCRModel::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_bgr, const std::vector<cv::RotatedRect> &last_rcs, const std::vector<std::string> &last_text)
+void OCRModel::handle_bgr_output(const cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &out_bgr_ts, cv::Mat &last_bgr,
+                                 const std::vector<cv::RotatedRect> &last_rcs, const std::vector<std::string> &last_text)
 {
-    // BGR output: visualize and optionally display
     if (!out_bgr.has_value())
     {
         return;
     }
 
+    // This was derived from the same branch in the G-API graph as out_bgr, so must also be present.
+    CV_Assert(out_bgr_ts.has_value());
+
+    // Now that we got a useful value, let's cache this one as the most recent.
     last_bgr = *out_bgr;
 
-    cv::Mat original_bgr;
-    last_bgr.copyTo(original_bgr);
+    // Mark up this frame with our preview function.
+    cv::Mat marked_up_bgr;
+    last_bgr.copyTo(marked_up_bgr);
+    this->preview(marked_up_bgr, last_rcs, last_text);
 
-    rtsp::update_data_raw(last_bgr);
-    this->preview(last_bgr, last_rcs, last_text);
-
-    if (this->status_msg.empty())
-    {
-        rtsp::update_data_result(last_bgr);
-    }
-    else
-    {
-        cv::Mat bgr_with_status;
-        last_bgr.copyTo(bgr_with_status);
-
-        util::put_text(bgr_with_status, this->status_msg);
-        rtsp::update_data_result(bgr_with_status);
-    }
+    // Stream the latest BGR frame.
+    this->stream_frames(last_bgr, marked_up_bgr, *out_bgr_ts);
 
     // Maybe save and export the retraining data at this point
-    this->save_retraining_data(original_bgr);
+    this->save_retraining_data(last_bgr);
 }
 
 void OCRModel::preview(cv::Mat &bgr, const std::vector<cv::RotatedRect> &last_rcs, const std::vector<std::string> &last_text) const
 {
-
-    /*Drawing text boxes and writing the text in BGR frame*/
     const auto num_labels = last_rcs.size();
 
-    for( std::size_t l=0; l<num_labels; l++)
+    for (size_t i=0; i < num_labels; i++)
     {
         //Draw bounding box for this rotated rectangle
-        const auto &rc = last_rcs[l];
+        const auto &rc = last_rcs[i];
         ocr::vis::drawRotatedRect(bgr, rc);
 
         // Draw text, if decoded
-        ocr::vis::drawText(bgr, rc, last_text[l]);
+        ocr::vis::drawText(bgr, rc, last_text[i]);
     }
 }
 
-void OCRModel::handle_inference_output(const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
-                                        const cv::optional<std::vector<cv::RotatedRect>> &out_txtrcs, std::vector<cv::RotatedRect> &last_rcs,
-                                        cv::optional<std::vector<cv::Mat>> &out_text, std::vector<std::string> &last_text)
+void OCRModel::handle_inference_output(const cv::optional<int64_t> &out_nn_ts,
+                                       const cv::optional<std::vector<cv::RotatedRect>> &out_txtrcs, std::vector<cv::RotatedRect> &last_rcs,
+                                       cv::optional<std::vector<cv::Mat>> &out_text, std::vector<std::string> &last_text)
 {
     if (!out_nn_ts.has_value())
     {
         return;
     }
 
-    // The below objects are on the same desynchronized path
-    // and are coming together
     CV_Assert(out_nn_ts.has_value());
-    CV_Assert(out_nn_seqno.has_value());
-
-    // Handling text detection outputs
     CV_Assert(out_text.has_value());
     CV_Assert(out_txtrcs->size() == out_text->size());
 
@@ -285,6 +285,12 @@ void OCRModel::handle_inference_output(const cv::optional<int64_t> &out_nn_ts, c
 
     // Send resulting message over IoT
     iot::msgs::send_message(iot::msgs::MsgChannel::NEURAL_NETWORK, msg);
+
+    // If we want to time-align our network inferences with camera frames, we need to
+    // do that here (now that we have a new inference to align in time with the frames we've been saving).
+    // The super class will check for us and handle this appropriately.
+    auto f_to_call_on_each_frame = [last_rcs, last_text, this](cv::Mat &frame){ this->preview(frame, last_rcs, last_text); };
+    this->handle_new_inference_for_time_alignment(*out_nn_ts, f_to_call_on_each_frame);
 }
 
 void OCRModel::log_parameters() const

--- a/azureeyemodule/app/model/ocr.hpp
+++ b/azureeyemodule/app/model/ocr.hpp
@@ -1,5 +1,12 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * This module is a good example of how to implement a cascaded model pipeline.
+ *
+ * This is an OCR (Optical Character Recognition) model, which takes two neural networks -
+ * a text detection and a language model, and runs them in series.
+ */
 #pragma once
 
 // standard library includes
@@ -22,33 +29,86 @@
 
 namespace model {
 
-/** A class to represent a OCR Model : Text Detection & Text Recognition Model on the Azure Percept Device */
+/** A class to represent an OCR Model. Uses two models: a text detection network and a text recognition network. */
 class OCRModel : public AzureEyeModel
 {
 public:
-    OCRModel( const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution);
+    /**
+     * Constructor.
+     *
+     * @param modelfpaths: In this model, we expect this to be a vector of length 2. The first one must point to the text detection network and the second
+     *                     must point to the language model. Model paths are strings that point to the model .blob files.
+     * @param mvcmd:       The Myriad X firmware binary. A running model owns the VPU, so it is responsible for initializing it as well.
+     * @param videofile:   If we pass a non-empty string here, the model will record frames to a file at this location as a .mp4.
+     * @param resolution:  The resolution mode to put the camera in.
+     */
+    OCRModel(const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution);
 
+    /** We invoke this method from main to run the network. It should return if there is a model update (found by checking this->restarting). */
     void run(cv::GStreamingCompiled* pipeline) override;
 
 private:
 
-    /** OCRDecoder is our TextDecoder which will run the CTCGreedy/ Beamsearch */
+    /** OCRDecoder is our TextDecoder state machine, which will run the CTC beamsearch over the language model's output. */
     ocr::TextDecoder OCRDecoder;
 
-    /** Compile the graph for classification model */
+    /** Compiles the G-API graph. */
     cv::GStreamingCompiled compile_cv_graph() const;
 
-    /** Pull data through the given pipeline. Returns true if we run out of frames, false if we have been interrupted. Otherwise runs forever. */
+    /** Pulls data through the given pipeline. Returns true if we run out of frames, false if we have been interrupted. Otherwise runs forever. */
     bool pull_data(cv::GStreamingCompiled &pipeline);
 
-    /** Update the BGR output to show the labels. */
-    void handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_bgr, const std::vector<cv::RotatedRect> &last_rcs, const std::vector<std::string> &last_text);
+    /**
+     * The G-API graph in this (and most classes) is split into three branches: a branch that handles the H.264 encoding, a branch that
+     * timestamps and forwards the raw camera BGR frames, and a branch that handles the neural network inferences.
+     *
+     * This method handles the outputs from the second branch - the raw BGR branch. It takes the latest BGR frame, updates `last_bgr` to it,
+     * and streams the frame out over the RTSP stream.
+     *
+     * Note that there is an option in the module twin to turn on time alignment. If we do NOT have that option turned on,
+     * we also stream the result frame here after applying last_rcs and last_text to it.
+     * If we DO have that option turned on, we ignore the marked up frame created by last_mask and instead store
+     * out_bgr (the raw BGR frame) into a buffer for use later, when we have a new neural network inference. At that point,
+     * we search through the buffer of old frames that we have to find the best matching one in time, and then mark up
+     * that frame and all older ones that we have not yet sent to the RTSP server. Then we release all of the marked up frames
+     * in a batch to the RTSP stream (which will churn through them at some specified frames per second rate).
+     *
+     * All of this time alignment stuff is mostly taken care of for you in the super class.
+     *
+     * @param out_bgr: The latest raw BGR frame from the G-API graph. This may be empty (because the graph is asynchronous), in
+     *                 which case we immediately return from this method.
+     * @param bgr_ts: The timestamp of out_bgr.
+     * @param last_bgr: We cache out_bgr into this for use in other methods.
+     * @param last_rcs: The latest output rectangles that we use to mark up the frame if we are not time aligning.
+     * @param last_text: The latest decoded strings to use to mark up the frame if we are not time aligning.
+     */
+    void handle_bgr_output(const cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &bgr_ts, cv::Mat &last_bgr,
+                           const std::vector<cv::RotatedRect> &last_rcs, const std::vector<std::string> &last_text);
 
-    /** Compose the RGB based on the labels. */
+    /** Draws the given rectangles and texts onto the frame. */
     void preview(cv::Mat &bgr, const std::vector<cv::RotatedRect> &last_rcs, const std::vector<std::string> &last_text) const;
 
-    /** Handle the detector's output */
-    void handle_inference_output(const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
+    /**
+     * The G-API graph in this (and most classes) is split into three branches: a branch that handles the H.264 encoding, a branch that
+     * timestamps and forwards the raw camera BGR frames, and a branch that handles the neural network inferences.
+     *
+     * This method handles the third branch - the neural network output branch. Whenever we get a new neural network output,
+     * we handle it by doing two things:
+     *
+     * 1. We compose a JSON message that says what texts we have detected.
+     *    Then we send this message out over IoT.
+     * 2. If we are time-aligning frames (see handle_bgr_output's documentation), we alert the super class that we have
+     *    a new inference. The super class will go search through the stored frames for the one most closely aligned in
+     *    time with the frame that this network was working on for this inference, and it marks up all the frames
+     *    from that point backwards, and then releases them to the RTSP server.
+     *
+     * @param out_nn_ts: The timestamp associated with the latest neural network inference.
+     * @param out_txtrcs: The rotated rectangle output from the neural network.
+     * @param last_rcs: We cache the rotated rectangels into this for use in other methods.
+     * @param out_text: The latest strings from the networks.
+     * @param last_text: We cache the latest strings into this for use in other methods.
+     */
+    void handle_inference_output(const cv::optional<int64_t> &out_nn_ts,
                                         const cv::optional<std::vector<cv::RotatedRect>> &out_txtrcs, std::vector<cv::RotatedRect> &last_rcs,
                                         cv::optional<std::vector<cv::Mat>> &out_text, std::vector<std::string> &last_text);
 

--- a/azureeyemodule/app/model/onnxssd.cpp
+++ b/azureeyemodule/app/model/onnxssd.cpp
@@ -166,9 +166,9 @@ bool ONNXSSDModel::pull_data(cv::GStreamingCompiled &pipeline){
     {
         if(out_boxes.has_value())
         {
-            this->handle_inference_output(out_bgr, out_bgr_ts, out_bgr_seqno, out_boxes, out_labels, out_confidences, out_size, last_boxes, last_labels, last_confidences);
+            this->handle_inference_output(out_bgr_ts, out_bgr_seqno, out_boxes, out_labels, out_confidences, out_size, last_boxes, last_labels, last_confidences);
         }
-        this->handle_bgr_output(out_bgr, last_bgr, last_boxes, last_labels, last_confidences);
+        this->handle_bgr_output(out_bgr, out_bgr_ts, last_bgr, last_boxes, last_labels, last_confidences);
 
         if (this->restarting)
         {

--- a/azureeyemodule/app/model/openpose.cpp
+++ b/azureeyemodule/app/model/openpose.cpp
@@ -51,7 +51,7 @@ static const std::pair<int, int> limb_keypoints_ids[] = {
 /** Width of the 'limbs' in viewing stuff */
 const int stick_width = 4;
 
-/** Declare an OpenPose network type. Takes one matrix and outputs two matrices. */
+/** Declare an OpenPose network type. Takes one matrix and outputs two matrices (part affinity fields and keypoints). */
 using openpose_output = std::tuple<cv::GMat, cv::GMat>;
 G_API_NET(OpenPoseNetwork, <openpose_output(cv::GMat)>, "com.intel.azure.open-pose");
 
@@ -64,7 +64,10 @@ void OpenPoseModel::run(cv::GStreamingCompiled* pipeline)
 {
     while (true)
     {
+        // We have to wait for the VPU to come up.
         this->wait_for_device();
+
+        // Log our meta data.
         this->log_parameters();
 
         // Build the camera pipeline with G-API
@@ -84,50 +87,58 @@ void OpenPoseModel::run(cv::GStreamingCompiled* pipeline)
 
 cv::GStreamingCompiled OpenPoseModel::compile_cv_graph() const
 {
-    // Declare an empty GMat - the beginning of the pipeline
+    // The input node of the G-API pipeline. This will be filled in, one frame at time.
     cv::GMat in;
+
+    // We have a custom preprocessing node for the Myriad X-attached camera.
     cv::GMat preproc = cv::gapi::mx::preproc(in, this->resolution);
+
+    // This path is the H.264 path. It gets our frames one at a time from
+    // the camera and encodes them into H.264.
     cv::GArray<uint8_t> h264;
     cv::GOpaque<int64_t> h264_seqno;
     cv::GOpaque<int64_t> h264_ts;
     std::tie(h264, h264_seqno, h264_ts) = cv::gapi::streaming::encH264ts(preproc);
 
-    // We have BGR output and H264 output in the same graph.
-    // In this case, BGR always must be desynchronized from the main path
-    // to avoid internal queue overflow (FW reports this data to us via
-    // separate channels)
-    // copy() is required only to maintain the graph contracts
-    // (there must be an operation following desync()). No real copy happens
+    // We branch off from the preproc node into H.264 (above), raw BGR output (here),
+    // and neural network inferences (below).
     cv::GMat img = cv::gapi::copy(cv::gapi::streaming::desync(preproc));
+    auto img_ts = cv::gapi::streaming::timestamp(img);
 
-    // This branch has inference and is desynchronized to keep
-    // a constant framerate for the encoded stream (above)
+    // This node branches off from the preproc node for neural network inferencing.
     cv::GMat bgr = cv::gapi::streaming::desync(preproc);
+    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(bgr);
 
+    // Here's where we actually run our neural network. It runs on the VPU.
     cv::GMat nn_pafs;
     cv::GMat nn_keys;
     std::tie(nn_pafs, nn_keys) = cv::gapi::infer<OpenPoseNetwork>(bgr);
 
+    // Grab some useful metadata
     cv::GOpaque<int64_t> nn_seqno = cv::gapi::streaming::seqNo(nn_keys);
-    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(nn_keys);
     cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(bgr);
 
+    // Here's where we post-process our network's outputs into a vector of HumanPose objects.
     cv::GArray<pose::HumanPose> skeletons = cv::gapi::streaming::parse_open_pose(nn_pafs, nn_keys, sz);
 
-    // Now specify the computation's boundaries
+    // Specify the boundaries of the G-API graph (the inputs and outputs).
     auto graph = cv::GComputation(cv::GIn(in),
-                                  cv::GOut(h264, h264_seqno, h264_ts,               // main path: H264 (~constant framerate)
-                                  img,                                              // desynchronized path: BGR
-                                  nn_seqno, nn_ts, nn_pafs, nn_keys, skeletons));   // Inference path
+                                  cv::GOut(h264, h264_seqno, h264_ts,      // The H.264 branch
+                                           img, img_ts,                    // The raw camera frame branch
+                                           nn_seqno, nn_ts, skeletons));   // The neural network inference path
 
+    // Pass the actual neural network blob file into the graph. We assume we have a modelfiles of length at least 1.
+    // We also configure our network to have two output layers.
+    CV_Assert(this->modelfiles.size() >= 1);
     auto networks = cv::gapi::networks(cv::gapi::mx::Params<OpenPoseNetwork>{ this->modelfiles.at(0) }.cfgOutputLayers({"Mconv7_stage2_L1", "Mconv7_stage2_L2"}));
 
+    // Here we wrap up all the kernels (the implementations of the G-API ops) that we need for our graph.
     auto kernels = cv::gapi::combine(cv::gapi::mx::kernels(), cv::gapi::kernels<cv::gapi::streaming::GOCVParseOpenPose>());
 
-    // Compile the graph in streamnig mode, set all the parameters
+    // Compile the graph in streamnig mode; set all the parameters; feed the firmware file into the VPU.
     auto pipeline = graph.compileStreaming(cv::gapi::mx::Camera::params(), cv::compile_args(networks, kernels, cv::gapi::mx::mvcmdFile{ this->mvcmd }));
 
-    // Specify the Azure Percept's Camera as the input to the pipeline, and start processing
+    // Specify the Azure Percept's Camera as the input to the pipeline.
     pipeline.setSource(cv::gapi::wip::make_src<cv::gapi::mx::Camera>());
 
     return pipeline;
@@ -135,23 +146,25 @@ cv::GStreamingCompiled OpenPoseModel::compile_cv_graph() const
 
 bool OpenPoseModel::pull_data(cv::GStreamingCompiled &pipeline)
 {
+    // The raw BGR frames from the camera will fill this node.
     cv::optional<cv::Mat> out_bgr;
+    cv::optional<int64_t> out_bgr_ts;
 
+    // The H.264 information will fill these nodes.
     cv::optional<std::vector<uint8_t>> out_h264;
     cv::optional<int64_t> out_h264_seqno;
     cv::optional<int64_t> out_h264_ts;
 
-    cv::optional<cv::Mat> out_pafs;
-    cv::optional<cv::Mat> out_keys;
+    // Our neural network's frames will fill out_mask, and timestamp will fill nn_ts.
     cv::optional<int64_t> out_nn_ts;
     cv::optional<int64_t> out_nn_seqno;
     cv::optional<std::vector<pose::HumanPose>> out_poses;
 
-    std::vector<int> last_labels;
-    std::vector<float> last_confidences;
+    // Because each node is asynchronusly filled, we cache them whenever we get them.
     std::vector<pose::HumanPose> last_poses;
     cv::Mat last_bgr;
 
+    // If the user wants to record a video, we open the video file.
     std::ofstream ofs;
     if (!this->videofile.empty())
     {
@@ -159,11 +172,11 @@ bool OpenPoseModel::pull_data(cv::GStreamingCompiled &pipeline)
     }
 
     // Pull the data from the pipeline while it is running
-    while (pipeline.pull(cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_nn_seqno, out_nn_ts, out_pafs, out_keys, out_poses)))
+    while (pipeline.pull(cv::gout(out_h264, out_h264_seqno, out_h264_ts, out_bgr, out_bgr_ts, out_nn_seqno, out_nn_ts, out_poses)))
     {
         this->handle_h264_output(out_h264, out_h264_ts, out_h264_seqno, ofs);
-        this->handle_inference_output(out_keys, out_nn_ts, out_nn_seqno, out_poses, last_poses);
-        this->handle_bgr_output(out_bgr, last_bgr, last_poses);
+        this->handle_inference_output(out_nn_ts, out_nn_seqno, out_poses, last_poses);
+        this->handle_bgr_output(out_bgr, out_bgr_ts, last_bgr, last_poses);
 
         if (this->restarting)
         {
@@ -177,37 +190,31 @@ bool OpenPoseModel::pull_data(cv::GStreamingCompiled &pipeline)
     return true;
 }
 
-void OpenPoseModel::handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_bgr, const std::vector<pose::HumanPose> &last_poses)
+void OpenPoseModel::handle_bgr_output(const cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &bgr_ts,
+                                      cv::Mat &last_bgr, const std::vector<pose::HumanPose> &last_poses)
 {
-    // BGR output: visualize and optionally display
+    // If out_bgr does not have anything in it, we didn't get anything from the G-API graph at this iteration.
     if (!out_bgr.has_value())
     {
         return;
     }
 
+    // This comes with out_bgr on the same branch of the G-API graph, so it must have a value if out_bgr does.
+    CV_Assert(bgr_ts.has_value());
+
+    // Now that we got a useful value, let's cache this one as the most recent.
     last_bgr = *out_bgr;
 
-    cv::Mat original_bgr;
-    last_bgr.copyTo(original_bgr);
+    // Mark up this frame with our preview function.
+    cv::Mat marked_up_bgr;
+    last_bgr.copyTo(marked_up_bgr);
+    this->preview(marked_up_bgr, last_poses);
 
-    rtsp::update_data_raw(last_bgr);
-    this->preview(last_bgr, last_poses);
-
-    if (this->status_msg.empty())
-    {
-        rtsp::update_data_result(last_bgr);
-    }
-    else
-    {
-        cv::Mat bgr_with_status;
-        last_bgr.copyTo(bgr_with_status);
-
-        util::put_text(bgr_with_status, this->status_msg);
-        rtsp::update_data_result(bgr_with_status);
-    }
+    // Stream the latest BGR frame.
+    this->stream_frames(last_bgr, marked_up_bgr, *bgr_ts);
 
     // Maybe save and export the retraining data at this point
-    this->save_retraining_data(original_bgr);
+    this->save_retraining_data(last_bgr);
 }
 
 void OpenPoseModel::preview(cv::Mat &bgr, const std::vector<pose::HumanPose> &poses) const
@@ -260,7 +267,7 @@ void OpenPoseModel::preview(cv::Mat &bgr, const std::vector<pose::HumanPose> &po
     cv::addWeighted(bgr, 0.4, pane, 0.6, 0, bgr);
 }
 
-void OpenPoseModel::handle_inference_output(const cv::optional<cv::Mat> &out_nn, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
+void OpenPoseModel::handle_inference_output(const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
                                             const cv::optional<std::vector<pose::HumanPose>> &out_poses, std::vector<pose::HumanPose> &last_poses)
 {
     if (!out_nn_ts.has_value())
@@ -268,8 +275,7 @@ void OpenPoseModel::handle_inference_output(const cv::optional<cv::Mat> &out_nn,
         return;
     }
 
-    // The below objects are on the same desynchronized path
-    // and are coming together
+    // These are all derived on the same branch of the G-API graph, so should come at the same time.
     CV_Assert(out_nn_ts.has_value());
     CV_Assert(out_nn_seqno.has_value());
     CV_Assert(out_poses.has_value());
@@ -291,8 +297,17 @@ void OpenPoseModel::handle_inference_output(const cv::optional<cv::Mat> &out_nn,
 
     last_poses = std::move(*out_poses);
 
+    // Log using a decaying filter so we don't bloat the log files.
     this->log_inference(msg);
+
+    // Send over IoT
     iot::msgs::send_message(iot::msgs::MsgChannel::NEURAL_NETWORK, msg);
+
+    // If we want to time-align our network inferences with camera frames, we need to
+    // do that here (now that we have a new inference to align in time with the frames we've been saving).
+    // The super class will check for us and handle this appropriately.
+    auto f_to_call_on_each_frame = [last_poses, this](cv::Mat &frame){ this->preview(frame, last_poses); };
+    this->handle_new_inference_for_time_alignment(*out_nn_ts, f_to_call_on_each_frame);
 }
 
 void OpenPoseModel::log_parameters() const

--- a/azureeyemodule/app/model/openpose.hpp
+++ b/azureeyemodule/app/model/openpose.hpp
@@ -1,5 +1,18 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ *
+ * OpenPose is a pose detection network, which has very good accuracy and good run time performance,
+ * but has an extremely complicated post-processing algorithm. See https://github.com/CMU-Perceptual-Computing-Lab/openpose
+ * for a reference implementation and https://arxiv.org/abs/1812.08008 for the paper.
+ *
+ * The gist of it is that the neural network outputs two tensors: a heatmap of keypoints (human keypoints - eyes, nose, arms, or whatever),
+ * and a "part affinity field", which is a tensor that encodes a vector field where each vector is pointing along a "limb" (like an arm or leg,
+ * but could be torso or face) from one keypoint to another.
+ *
+ * The post-processing algorithm takes these two tensors and combines their information to produce a skeletal pose.
+ * Most of the details are hidden in the kernel file and the openpose folder.
+ */
 #pragma once
 
 #include "azureeyemodel.hpp"
@@ -8,29 +21,83 @@
 
 namespace model {
 
+/**
+ * A class for detecting skeletal pose of humans.
+ */
 class OpenPoseModel : public AzureEyeModel
 {
 public:
+    /**
+     * Constructor.
+     *
+     * @param modelfpaths: In this model, we expect this to be a vector of length 1 (all model constructors take a vector of paths, but most only use 1 model path).
+     *                     Model paths are strings that point to the model .blob files. If you are developing a cascaded model (see ocr for example), you will
+     *                     need to pass a model file for each network in the cascade.
+     * @param mvcmd:       The Myriad X firmware binary. A running model owns the VPU, so it is responsible for initializing it as well.
+     * @param videofile:   If we pass a non-empty string here, the model will record frames to a file at this location as a .mp4.
+     * @param resolution:  The resolution mode to put the camera in.
+     */
     OpenPoseModel(const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution);
 
+    /** We invoke this method from main to run the network. It should return if there is a model update (found by checking this->restarting). */
     void run(cv::GStreamingCompiled* pipeline) override;
 
 private:
-    /** Compile the pipeline graph for OpenPose. */
+    /** Compiles the G-API graph. */
     cv::GStreamingCompiled compile_cv_graph() const;
 
-    /** Pull data through the given pipeline. Returns true if we run out of frames, false if we have been interrupted. Otherwise runs forever. */
+    /** Pulls data through the given pipeline. Returns true if we run out of frames, false if we have been interrupted. Otherwise runs forever. */
     bool pull_data(cv::GStreamingCompiled &pipeline);
 
-    /** Compose the BGR frame with the skeletons */
-    void handle_bgr_output(cv::optional<cv::Mat> &out_bgr, cv::Mat &last_bgr, const std::vector<pose::HumanPose> &poses);
+    /**
+     * The G-API graph in this (and most classes) is split into three branches: a branch that handles the H.264 encoding, a branch that
+     * timestamps and forwards the raw camera BGR frames, and a branch that handles the neural network inferences.
+     *
+     * This method handles the outputs from the second branch - the raw BGR branch. It takes the latest BGR frame, updates `last_bgr` to it,
+     * and streams the frame out over the RTSP stream.
+     *
+     * Note that there is an option in the module twin to turn on time alignment. If we do NOT have that option turned on,
+     * we also stream the result frame here after applying `poses` to it.
+     * If we DO have that option turned on, we ignore the marked up frame created by last_mask and instead store
+     * out_bgr (the raw BGR frame) into a buffer for use later, when we have a new neural network inference. At that point,
+     * we search through the buffer of old frames that we have to find the best matching one in time, and then mark up
+     * that frame and all older ones that we have not yet sent to the RTSP server. Then we release all of the marked up frames
+     * in a batch to the RTSP stream (which will churn through them at some specified frames per second rate).
+     *
+     * All of this time alignment stuff is mostly taken care of for you in the super class.
+     *
+     * @param out_bgr: The latest raw BGR frame from the G-API graph. This may be empty (because the graph is asynchronous), in
+     *                 which case we immediately return from this method.
+     * @param bgr_ts: The timestamp of out_bgr.
+     * @param last_bgr: We cache out_bgr into this for use in other methods.
+     * @param poses: The latest poses to use if we are not time aligning the result frames.
+     */
+    void handle_bgr_output(const cv::optional<cv::Mat> &out_bgr, const cv::optional<int64_t> &bgr_ts, cv::Mat &last_bgr, const std::vector<pose::HumanPose> &poses);
 
     /** Compose the RGB based on the poses. */
     void preview(cv::Mat &bgr, const std::vector<pose::HumanPose> &poses) const;
 
-    /** Handle the pose estimation model's output */
-    void handle_inference_output(const cv::optional<cv::Mat> &out_nn, const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
-                                                const cv::optional<std::vector<pose::HumanPose>> &out_poses, std::vector<pose::HumanPose> &last_poses);
+    /**
+     * The G-API graph in this (and most classes) is split into three branches: a branch that handles the H.264 encoding, a branch that
+     * timestamps and forwards the raw camera BGR frames, and a branch that handles the neural network inferences.
+     *
+     * This method handles the third branch - the neural network output branch. Whenever we get a new neural network output,
+     * we handle it by doing two things:
+     *
+     * 1. We compose a JSON message that says what percentage of the image is occupied by the detected object(s).
+     *    Then we send this message out over IoT.
+     * 2. If we are time-aligning frames (see handle_bgr_output's documentation), we alert the super class that we have
+     *    a new inference. The super class will go search through the stored frames for the one most closely aligned in
+     *    time with the frame that this network was working on for this inference, and it marks up all the frames
+     *    from that point backwards, and then releases them to the RTSP server.
+     *
+     * @param out_nn_ts: The timestamp for the frame the network used to derive the poses.
+     * @param out_nn_seqno: The frame number for the frame the network used to derive the poses.
+     * @param out_poses: The latest poses from the neural network. If this is empty, we return immediately.
+     * @param last_poses: We cache the latest poses into this for use in other methods.
+     */
+    void handle_inference_output(const cv::optional<int64_t> &out_nn_ts, const cv::optional<int64_t> &out_nn_seqno,
+                                 const cv::optional<std::vector<pose::HumanPose>> &out_poses, std::vector<pose::HumanPose> &last_poses);
 
     /** Print out all the model's meta information. */
     void log_parameters() const;

--- a/azureeyemodule/app/model/s1.cpp
+++ b/azureeyemodule/app/model/s1.cpp
@@ -31,14 +31,17 @@ S1Model::S1Model(const std::string &labelfpath, const std::vector<std::string> &
 {
 }
 
-void S1Model::run(cv::GStreamingCompiled* pipeline)
+void S1Model::run(cv::GStreamingCompiled *pipeline)
 {
     while (true)
     {
+        // Have to wait for the VPU to come up.
         this->wait_for_device();
 
-        // Read in the labels for classification
+        // Read in the labels for classification.
         label::load_label_file(this->class_labels, this->labelfpath);
+
+        // Log the meta data for this class.
         this->log_parameters();
 
         // Build the camera pipeline with G-API
@@ -58,53 +61,60 @@ void S1Model::run(cv::GStreamingCompiled* pipeline)
 
 cv::GStreamingCompiled S1Model::compile_cv_graph() const
 {
-    // Declare an empty GMat - the beginning of the pipeline
+    // The input node of the G-API pipeline. This will be filled in, one frame at time.
     cv::GMat in;
+
+    // We have a custom preprocessing node for the Myriad X-attached camera.
     cv::GMat preproc = cv::gapi::mx::preproc(in, this->resolution);
+
+    // This path is the H.264 path. It gets our frames one at a time from
+    // the camera and encodes them into H.264.
     cv::GArray<uint8_t> h264;
     cv::GOpaque<int64_t> h264_seqno;
     cv::GOpaque<int64_t> h264_ts;
     std::tie(h264, h264_seqno, h264_ts) = cv::gapi::streaming::encH264ts(preproc);
 
-    // We have BGR output and H264 output in the same graph.
-    // In this case, BGR always must be desynchronized from the main path
-    // to avoid internal queue overflow (FW reports this data to us via
-    // separate channels)
-    // copy() is required only to maintain the graph contracts
-    // (there must be an operation following desync()). No real copy happens
+    // We branch off from the preproc node into H.264 (above), raw BGR output (here),
+    // and neural network inferences (below).
     cv::GMat img = cv::gapi::copy(cv::gapi::streaming::desync(preproc));
+    cv::GOpaque<int64_t> img_ts = cv::gapi::streaming::timestamp(img);
 
-    // This branch has inference and is desynchronized to keep
-    // a constant framerate for the encoded stream (above)
+    // This node branches off from the preproc node for neural network inferencing.
     cv::GMat bgr = cv::gapi::streaming::desync(preproc);
+    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(bgr);
 
+    // Here's where we actually run our neural network. It runs on the VPU.
     cv::GMat nn, nn2;
     std::tie(nn, nn2) = cv::gapi::infer<MultiOutput>(bgr);
 
+    // Get some useful metadata.
     cv::GOpaque<int64_t> nn_seqno = cv::gapi::streaming::seqNo(nn);
-    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(nn);
     cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(bgr);
 
+    // Here's where we post-process our network's outputs into bounding boxes, IDs, and confidences.
     cv::GArray<cv::Rect> rcs;
     cv::GArray<int> ids;
     cv::GArray<float> cfs;
-
     std::tie(rcs, ids, cfs) = cv::gapi::streaming::parseS1WithConf(nn, nn2, sz);
 
-    // Now specify the computation's boundaries
+    // Specify the boundaries of the G-API graph (the inputs and outputs).
     auto graph = cv::GComputation(cv::GIn(in),
-                                  cv::GOut(h264, h264_seqno, h264_ts,      // main path: H264 (~constant framerate)
-                                  img,                                     // desynchronized path: BGR
-                                  nn_seqno, nn_ts, rcs, ids, cfs, sz));
+                                  cv::GOut(h264, h264_seqno, h264_ts,               // H.264 branch
+                                           img, img_ts,                             // Raw frame branch
+                                           nn_seqno, nn_ts, rcs, ids, cfs, sz));    // Neural network inference branch
 
-    auto networks = cv::gapi::networks(cv::gapi::mx::Params<MultiOutput>{modelfiles.at(0)}.cfgOutputLayers({ "raw_boxes", "raw_probs" }));
+    // Pass the actual neural network blob file into the graph. We assume we have a modelfiles of length at least 1.
+    // We have to configure this network's output layers as well, since there are two.
+    CV_Assert(this->modelfiles.size() >= 1);
+    auto networks = cv::gapi::networks(cv::gapi::mx::Params<MultiOutput>{this->modelfiles.at(0)}.cfgOutputLayers({ "raw_boxes", "raw_probs" }));
 
+    // Here we wrap up all the kernels (the implementations of the G-API ops) that we need for our graph.
     auto kernels = cv::gapi::combine(cv::gapi::mx::kernels(), cv::gapi::kernels<cv::gapi::streaming::GOCVParseS1WithConf>());
 
-    // Compile the graph in streamnig mode, set all the parameters
+    // Compile the graph in streamnig mode; set all the parameters; feed the firmware file into the VPU.
     auto pipeline = graph.compileStreaming(cv::gapi::mx::Camera::params(), cv::compile_args(networks, kernels, cv::gapi::mx::mvcmdFile{ this->mvcmd }));
 
-    // Specify the Azure Percept's Camera as the input to the pipeline, and start processing
+    // Specify the Percept DK's camera as the input to the pipeline.
     pipeline.setSource(cv::gapi::wip::make_src<cv::gapi::mx::Camera>());
 
     return pipeline;

--- a/azureeyemodule/app/model/s1.hpp
+++ b/azureeyemodule/app/model/s1.hpp
@@ -17,11 +17,23 @@
 
 namespace model {
 
+/** An S1 Model is a type of object detector used by Custom Vision. */
 class S1Model : public ObjectDetector
 {
 public:
+    /**
+     * Constructor.
+     *
+     * @param modelfpaths: In this model, we expect this to be a vector of length 1 (all model constructors take a vector of paths, but most only use 1 model path).
+     *                     Model paths are strings that point to the model .blob files. If you are developing a cascaded model (see ocr for example), you will
+     *                     need to pass a model file for each network in the cascade.
+     * @param mvcmd:       The Myriad X firmware binary. A running model owns the VPU, so it is responsible for initializing it as well.
+     * @param videofile:   If we pass a non-empty string here, the model will record frames to a file at this location as a .mp4.
+     * @param resolution:  The resolution mode to put the camera in.
+     */
     S1Model(const std::string &labelfpath, const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution);
 
+    /** We invoke this method from main to run the network. It should return if there is a model update (found by checking this->restarting). */
     void run(cv::GStreamingCompiled* pipeline) override;
 
 private:

--- a/azureeyemodule/app/model/ssd.cpp
+++ b/azureeyemodule/app/model/ssd.cpp
@@ -26,7 +26,6 @@ namespace model {
 /** An SSD network takes a single input and outputs a single output (which we will parse into boxes, labels, and confidences) */
 G_API_NET(SSDNetwork, <cv::GMat(cv::GMat)>, "ssd-network");
 
-
 SSDModel::SSDModel(const std::string &labelfpath, const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution)
     : ObjectDetector{ labelfpath, modelfpaths, mvcmd, videofile, resolution }
 {
@@ -44,14 +43,17 @@ void SSDModel::load_default()
     this->labelfpath = "/app/data/labels.txt";
 }
 
-void SSDModel::run(cv::GStreamingCompiled* pipeline)
+void SSDModel::run(cv::GStreamingCompiled *pipeline)
 {
     while (true)
     {
+        // Wait for the VPU to come up.
         this->wait_for_device();
 
         // Read in the labels for classification
         label::load_label_file(this->class_labels, this->labelfpath);
+
+        // Log some metadata.
         this->log_parameters();
 
         // Build the camera pipeline with G-API
@@ -61,7 +63,6 @@ void SSDModel::run(cv::GStreamingCompiled* pipeline)
 
         // Pull data through the pipeline
         bool ran_out_naturally = this->pull_data(*pipeline);
-
         if (!ran_out_naturally)
         {
             break;
@@ -71,52 +72,58 @@ void SSDModel::run(cv::GStreamingCompiled* pipeline)
 
 cv::GStreamingCompiled SSDModel::compile_cv_graph() const
 {
-    // Declare an empty GMat - the beginning of the pipeline
+    // The input node of the G-API pipeline. This will be filled in, one frame at time.
     cv::GMat in;
+
+    // We have a custom preprocessing node for the Myriad X-attached camera.
     cv::GMat preproc = cv::gapi::mx::preproc(in, this->resolution);
+
+    // This path is the H.264 path. It gets our frames one at a time from
+    // the camera and encodes them into H.264.
     cv::GArray<uint8_t> h264;
     cv::GOpaque<int64_t> h264_seqno;
     cv::GOpaque<int64_t> h264_ts;
     std::tie(h264, h264_seqno, h264_ts) = cv::gapi::streaming::encH264ts(preproc);
 
-    // We have BGR output and H264 output in the same graph.
-    // In this case, BGR always must be desynchronized from the main path
-    // to avoid internal queue overflow (FW reports this data to us via
-    // separate channels)
-    // copy() is required only to maintain the graph contracts
-    // (there must be an operation following desync()). No real copy happens
+    // We branch off from the preproc node into H.264 (above), raw BGR output (here),
+    // and neural network inferences (below).
     cv::GMat img = cv::gapi::copy(cv::gapi::streaming::desync(preproc));
+    cv::GOpaque<int64_t> img_ts = cv::gapi::streaming::timestamp(img);
 
-    // This branch has inference and is desynchronized to keep
-    // a constant framerate for the encoded stream (above)
+    // This node branches off from the preproc node for neural network inferencing.
     cv::GMat bgr = cv::gapi::streaming::desync(preproc);
+    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(bgr);
 
+    // Here's where we actually run our neural network. It runs on the VPU.
     cv::GMat nn = cv::gapi::infer<SSDNetwork>(bgr);
 
+    // Get some useful metadata.
     cv::GOpaque<int64_t> nn_seqno = cv::gapi::streaming::seqNo(nn);
-    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(nn);
     cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(bgr);
 
+    // Here's where we post-process our network's outputs into bounding boxes, IDs, and confidences.
     cv::GArray<cv::Rect> rcs;
     cv::GArray<int> ids;
     cv::GArray<float> cfs;
-
     std::tie(rcs, ids, cfs) = cv::gapi::streaming::parseSSDWithConf(nn, sz);
 
-    // Now specify the computation's boundaries
+    // Specify the boundaries of the G-API graph (the inputs and outputs).
     auto graph = cv::GComputation(cv::GIn(in),
-                                  cv::GOut(h264, h264_seqno, h264_ts,      // main path: H264 (~constant framerate)
-                                  img,                                     // desynchronized path: BGR
-                                  nn_seqno, nn_ts, rcs, ids, cfs, sz));    // Inference path
+                                  cv::GOut(h264, h264_seqno, h264_ts,               // H.264 branch
+                                          img, img_ts,                              // Raw frame branch
+                                          nn_seqno, nn_ts, rcs, ids, cfs, sz));     // Inference branch
 
+    // Pass the actual neural network blob file into the graph. We assume we have a modelfiles of at least length 1.
+    CV_Assert(this->modelfiles.size() >= 1);
     auto networks = cv::gapi::networks(cv::gapi::mx::Params<SSDNetwork>{this->modelfiles.at(0)});
 
+    // Here we wrap up all the kernels (the implementations of the G-API ops) that we need for our graph.
     auto kernels = cv::gapi::combine(cv::gapi::mx::kernels(), cv::gapi::kernels<cv::gapi::streaming::GOCVParseSSDWithConf>());
 
-    // Compile the graph in streamnig mode, set all the parameters
+    // Compile the graph in streamnig mode; set all the parameters; feed the firmware file into the VPU.
     auto pipeline = graph.compileStreaming(cv::gapi::mx::Camera::params(), cv::compile_args(networks, kernels, cv::gapi::mx::mvcmdFile{ this->mvcmd }));
 
-    // Specify the Azure Percept's Camera as the input to the pipeline, and start processing
+    // Specify the Percept DK's camera as the input to the pipeline.
     pipeline.setSource(cv::gapi::wip::make_src<cv::gapi::mx::Camera>());
 
     return pipeline;

--- a/azureeyemodule/app/model/ssd.hpp
+++ b/azureeyemodule/app/model/ssd.hpp
@@ -24,6 +24,18 @@ namespace model {
 class SSDModel : public ObjectDetector
 {
 public:
+    /**
+     * Constructor.
+     *
+     * @param labelfpath: Path to a file containing one label per line. The labels should correspond to the class index
+     *                    such that the first line should contain the label for the first class index.
+     * @param modelfpaths: In this model, we expect this to be a vector of length 1 (all model constructors take a vector of paths, but most only use 1 model path).
+     *                     Model paths are strings that point to the model .blob files. If you are developing a cascaded model (see ocr for example), you will
+     *                     need to pass a model file for each network in the cascade.
+     * @param mvcmd:       The Myriad X firmware binary. A running model owns the VPU, so it is responsible for initializing it as well.
+     * @param videofile:   If we pass a non-empty string here, the model will record frames to a file at this location as a .mp4.
+     * @param resolution:  The resolution mode to put the camera in.
+     */
     SSDModel(const std::string &labelfpath, const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution);
 
     /**
@@ -32,6 +44,7 @@ public:
      */
     void load_default();
 
+    /** We invoke this method from main to run the network. It should return if there is a model update (found by checking this->restarting). */
     void run(cv::GStreamingCompiled* pipeline) override;
 
 private:

--- a/azureeyemodule/app/model/yolo.cpp
+++ b/azureeyemodule/app/model/yolo.cpp
@@ -30,14 +30,17 @@ YoloModel::YoloModel(const std::string &labelfpath, const std::vector<std::strin
 {
 }
 
-void YoloModel::run(cv::GStreamingCompiled* pipeline)
+void YoloModel::run(cv::GStreamingCompiled *pipeline)
 {
     while (true)
     {
+        // Wait for the VPU to come up.
         this->wait_for_device();
 
         // Read in the labels for classification
         label::load_label_file(this->class_labels, this->labelfpath);
+
+        // Log some metadata.
         this->log_parameters();
 
         // Build the camera pipeline with G-API
@@ -47,7 +50,6 @@ void YoloModel::run(cv::GStreamingCompiled* pipeline)
 
         // Pull data through the pipeline
         bool ran_out_naturally = this->pull_data(*pipeline);
-
         if (!ran_out_naturally)
         {
             break;
@@ -57,52 +59,58 @@ void YoloModel::run(cv::GStreamingCompiled* pipeline)
 
 cv::GStreamingCompiled YoloModel::compile_cv_graph() const
 {
-    // Declare an empty GMat - the beginning of the pipeline
+    // The input node of the G-API pipeline. This will be filled in, one frame at time.
     cv::GMat in;
+
+    // We have a custom preprocessing node for the Myriad X-attached camera.
     cv::GMat preproc = cv::gapi::mx::preproc(in, this->resolution);
+
+    // This path is the H.264 path. It gets our frames one at a time from
+    // the camera and encodes them into H.264.
     cv::GArray<uint8_t> h264;
     cv::GOpaque<int64_t> h264_seqno;
     cv::GOpaque<int64_t> h264_ts;
     std::tie(h264, h264_seqno, h264_ts) = cv::gapi::streaming::encH264ts(preproc);
 
-    // We have BGR output and H264 output in the same graph.
-    // In this case, BGR always must be desynchronized from the main path
-    // to avoid internal queue overflow (FW reports this data to us via
-    // separate channels)
-    // copy() is required only to maintain the graph contracts
-    // (there must be an operation following desync()). No real copy happens
+    // We branch off from the preproc node into H.264 (above), raw BGR output (here),
+    // and neural network inferences (below).
     cv::GMat img = cv::gapi::copy(cv::gapi::streaming::desync(preproc));
+    cv::GOpaque<int64_t> img_ts = cv::gapi::streaming::timestamp(img);
 
-    // This branch has inference and is desynchronized to keep
-    // a constant framerate for the encoded stream (above)
+    // This node branches off from the preproc node for neural network inferencing.
     cv::GMat bgr = cv::gapi::streaming::desync(preproc);
+    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(preproc);
 
+    // Here's where we actually run our neural network. It runs on the VPU.
     cv::GMat nn = cv::gapi::infer<YOLONetwork>(bgr);
 
+    // Get some useful metadata.
     cv::GOpaque<int64_t> nn_seqno = cv::gapi::streaming::seqNo(nn);
-    cv::GOpaque<int64_t> nn_ts = cv::gapi::streaming::timestamp(nn);
     cv::GOpaque<cv::Size> sz = cv::gapi::streaming::size(bgr);
 
+    // Here's where we post-process our network's outputs into bounding boxes, IDs, and confidences.
     cv::GArray<cv::Rect> rcs;
     cv::GArray<int> ids;
     cv::GArray<float> cfs;
-
     std::tie(rcs, ids, cfs) = cv::gapi::streaming::parseYoloWithConf(nn, sz);
 
-    // Now specify the computation's boundaries
+    // Specify the boundaries of the G-API graph (the inputs and outputs).
     auto graph = cv::GComputation(cv::GIn(in),
-                                  cv::GOut(h264, h264_seqno, h264_ts,      // main path: H264 (~constant framerate)
-                                  img,                                     // desynchronized path: BGR
-                                  nn_seqno, nn_ts, rcs, ids, cfs, sz));
+                                  cv::GOut(h264, h264_seqno, h264_ts,               // H.264 branch
+                                           img, img_ts,                             // Raw frame branch
+                                           nn_seqno, nn_ts, rcs, ids, cfs, sz));    // Neural network inference branch
 
+    // Pass the actual neural network blob file into the graph. We assume we have a modelfiles of at least length 1.
+    CV_Assert(this->modelfiles.size() >= 1);
     auto networks = cv::gapi::networks(cv::gapi::mx::Params<YOLONetwork>{this->modelfiles.at(0)});
 
+    // Here we wrap up all the kernels (the implementations of the G-API ops) that we need for our graph.
     auto kernels = cv::gapi::combine(cv::gapi::mx::kernels(), cv::gapi::kernels<cv::gapi::streaming::GOCVParseYoloWithConf>());
 
-    // Compile the graph in streamnig mode, set all the parameters
+    // Compile the graph in streamnig mode; set all the parameters; feed the firmware file into the VPU.
     auto pipeline = graph.compileStreaming(cv::gapi::mx::Camera::params(), cv::compile_args(networks, kernels, cv::gapi::mx::mvcmdFile{ this->mvcmd }));
 
-    // Specify the Azure Percept's Camera as the input to the pipeline, and start processing
+    // Specify the Percept DK's camera as the input to the pipeline.
     pipeline.setSource(cv::gapi::wip::make_src<cv::gapi::mx::Camera>());
 
     return pipeline;

--- a/azureeyemodule/app/model/yolo.hpp
+++ b/azureeyemodule/app/model/yolo.hpp
@@ -24,8 +24,21 @@ namespace model {
 class YoloModel : public ObjectDetector
 {
 public:
+    /**
+     * Constructor.
+     *
+     * @param labelfpath: Path to a file containing one label per line. The labels should correspond to the class index
+     *                    such that the first line should contain the label for the first class index.
+     * @param modelfpaths: In this model, we expect this to be a vector of length 1 (all model constructors take a vector of paths, but most only use 1 model path).
+     *                     Model paths are strings that point to the model .blob files. If you are developing a cascaded model (see ocr for example), you will
+     *                     need to pass a model file for each network in the cascade.
+     * @param mvcmd:       The Myriad X firmware binary. A running model owns the VPU, so it is responsible for initializing it as well.
+     * @param videofile:   If we pass a non-empty string here, the model will record frames to a file at this location as a .mp4.
+     * @param resolution:  The resolution mode to put the camera in.
+     */
     YoloModel(const std::string &labelfpath, const std::vector<std::string> &modelfpaths, const std::string &mvcmd, const std::string &videofile, const cv::gapi::mx::Camera::Mode &resolution);
 
+    /** We invoke this method from main to run the network. It should return if there is a model update (found by checking this->restarting). */
     void run(cv::GStreamingCompiled* pipeline) override;
 
 private:

--- a/azureeyemodule/app/streaming/framebuffer.cpp
+++ b/azureeyemodule/app/streaming/framebuffer.cpp
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Standard library includes
+#include <chrono>
+#include <thread>
+
+// Local includes
+#include "framebuffer.hpp"
+#include "resolution.hpp"
+#include "../util/circular_buffer.hpp"
+#include "../util/helper.hpp"
+
+// Third party includes
+#include <opencv2/core/utility.hpp>
+#include <opencv2/imgproc.hpp>
+
+namespace rtsp {
+
+FrameBuffer::FrameBuffer(size_t max_length, int fps)
+    : circular_buffer(max_length), cached_frame(DEFAULT_HEIGHT, DEFAULT_WIDTH, CV_8UC3, cv::Scalar(0, 0, 0)),
+      fps(fps), fps_thread( std::thread([this]{this->periodically_update_frame();}) )
+{
+}
+
+FrameBuffer::~FrameBuffer()
+{
+    // Signal the thread we are terminating
+    this->shut_down = true;
+
+    // Wait for it to join. This could take up to 1/FPS seconds.
+    this->fps_thread.join();
+}
+
+cv::Mat FrameBuffer::get(const Resolution &resolution)
+{
+    // Readers may have to wait for the fps_update thread to update the latest frame,
+    // but that shouldn't take long.
+
+    cv::Mat ret;
+
+    // Take the mutex in order to read the cached frame (which may
+    // be in the middle of being updated by the FPS thread)
+    this->cached_frame_mutex.lock();
+    this->cached_frame.copyTo(ret);
+    this->cached_frame_mutex.unlock();
+
+    // Determine the resolution the caller wants
+    int desired_height;
+    int desired_width;
+    std::tie(desired_height, desired_width) = get_height_and_width(resolution);
+
+    // What resolution is the image that we got?
+    int ret_height = ret.size().height;
+    int ret_width = ret.size().width;
+
+    // If not the right resolution, we should update.
+    if ((ret_height != desired_height) || (ret_width != desired_width))
+    {
+        cv::resize(ret, ret, cv::Size(desired_width, desired_height));
+    }
+
+    return ret;
+}
+
+void FrameBuffer::put(const cv::Mat &frame)
+{
+    // Writers block until they put a frame into the buffer, but nobody actually blocks reading
+    // from the buffer in this design, so we should always succeed without waiting.
+    // Unless in the future we re-use this class for some other purpose or have multiple writers.
+    this->circular_buffer.put(frame);
+}
+
+void FrameBuffer::periodically_update_frame()
+{
+    while (!this->shut_down)
+    {
+        // Try to grab the next frame from the buffer, but it might be empty,
+        // or it might be in the middle of a put(). Either way, we don't have
+        // time to wait on this thread, as we may be running at a high FPS.
+        // We'll just catch it again next time.
+        cv::Mat frame;
+        bool got = this->circular_buffer.get_no_wait(frame);
+
+        // We do need to grab the cached_frame lock though.
+        if (got)
+        {
+            this->cached_frame_mutex.lock();
+            this->cached_frame = frame.clone();
+            this->cached_frame_mutex.unlock();
+        }
+
+        // Sleep for (1.0 / fps) seconds.
+        assert(this->fps != 0);
+        double one_over_fps = 1.0 / (double)this->fps;
+        double sleep_duration_ms = std::ceil(one_over_fps * 1000.0);
+        std::this_thread::sleep_for(std::chrono::milliseconds((int64_t)sleep_duration_ms));
+    }
+}
+
+size_t FrameBuffer::room() const
+{
+    auto capacity = this->circular_buffer.capacity();
+    auto size = this->circular_buffer.size_no_wait();
+    if (size > capacity)
+    {
+        // We won the lottery! Someone happened to be updating the circular buffer
+        // in just the right way at just the right time so that calling size_no_wait()
+        // returned something bogus.
+        // Safest thing to do in this most unlikely of circumstances is to return 0.
+        util::log_debug("FrameBuffer::room() got a bogus value from circular_buffer.size_no_wait(): " + std::to_string(size) + " when capacity is " + std::to_string(capacity));
+        return 0;
+    }
+    else
+    {
+        return capacity - size;
+    }
+}
+
+void FrameBuffer::set_fps(int fps)
+{
+    this->fps.exchange(fps);
+}
+
+} // namespace rtsp

--- a/azureeyemodule/app/streaming/framebuffer.hpp
+++ b/azureeyemodule/app/streaming/framebuffer.hpp
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+// Standard library includes
+#include <atomic>
+#include <thread>
+
+// Local includes
+#include "resolution.hpp"
+#include "../util/circular_buffer.hpp"
+
+// Third party includes
+#include <opencv2/core/utility.hpp>
+#include <opencv2/imgproc.hpp>
+
+
+namespace rtsp {
+
+/**
+ * A FrameBuffer represents a circular queue of frames to be sent out over RTSP.
+ * When the frame would be empty, we just keep feeding out the last frame again and again.
+ *
+ * Getting a frame from the buffer does not remove it, instead, we maintain a rate
+ * at which we want to change frames, and remove them at that rate. Every time
+ * a client wants to get a frame from this buffer, we return the current frame.
+ *
+ * Therefore, this class can be read by multiple clients who all expect to get the same
+ * information.
+ *
+ * Each framebuffer starts with a default frame, which will be what it sends out until
+ * it gets something else.
+ *
+ * This is thread-safe. You can read and write to this concurrently.
+ *
+ * The rationale for this class is time alignment. If the neural network
+ * wants to align its inferences in time, it needs to buffer up some number
+ * of old raw frames until it gets a network inference. Then it goes
+ * through the old frames to find the one that best matches in time
+ * with the frame the network used to derive its inferences.
+ * Once it finds the right frame, it marks up that frame and all older frames
+ * with that information, then dumps all of those frames into this buffer.
+ *
+ * Without the need for time alignment, we could just have a single latest
+ * frame, which would be updated every time we get a new one, which is
+ * what we used to do.
+ */
+class FrameBuffer
+{
+public:
+    /**
+     * Constructor for the FrameBuffer class.
+     *
+     * @param max_length: The maximum number of frames to store in the buffer before old ones get written over.
+     *                    If this number is too small, we may get a dump of frames from the neural network
+     *                    of a longer length than we can handle. In that case, we will dump some of those frames
+     *                    as we wrap around the buffer, creating a jump in time in the stream that is jarring
+     *                    to the viewer.
+     * @param fps: The frames per second at which to update the `get` frame. GStreamer RTSP server will call
+     *             the `get()` method at some frames per second, which may be different than this, but if the
+     *             FPS values differ, you might send duplicate frames or you might not send frames as often as
+     *             you could. Best to make sure this value remains about the same as the RTSP server's.
+     */
+    explicit FrameBuffer(size_t max_length, int fps);
+
+    /** Destructor. */
+    ~FrameBuffer();
+
+    /**
+     * We return the current frame.
+     * We adjust the retrieved frame to the right resolution if it isn't already that resolution.
+     * This may block up to as long as it takes for the internal FPS updating thread to update
+     * the frame, which should be quite quick.
+     */
+    cv::Mat get(const Resolution &resolution);
+
+    /** Put a new frame into the buffer. */
+    void put(const cv::Mat &frame);
+
+    /** Get the number of frames we still have room for before we start overwriting old ones. */
+    size_t room() const;
+
+    /** Set the rate at which we update the `get` frame. */
+    void set_fps(int fps);
+
+private:
+    /** The internal container we use for holding the frames. */
+    circbuf::CircularBuffer<cv::Mat> circular_buffer;
+
+    /** This is the latest frame that we have sent (or a default if we haven't sent any yet). */
+    cv::Mat cached_frame;
+
+    /** Lock to guard access to the cached frame, which gets read from whatever thread, and written from our internal thread. */
+    std::mutex cached_frame_mutex;
+
+    /** The frames per second that we update our cached frame. */
+    std::atomic<int> fps;
+
+    /** The FPS thread. This thread updates the `get` frame `fps` times per second. */
+    std::thread fps_thread;
+
+    /** When set to true, this signals the internal fps_thread to join. It will join at the next opportunity. */
+    bool shut_down = false;
+
+    /** The method our fps_thread runs. */
+    void periodically_update_frame();
+};
+
+} // namespace rtsp

--- a/azureeyemodule/app/streaming/resolution.cpp
+++ b/azureeyemodule/app/streaming/resolution.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Local includes
+#include "resolution.hpp"
+#include "../util/helper.hpp"
+
+// Standard library includes
+#include <assert.h>
+#include <string>
+
+namespace rtsp {
+
+std::string resolution_to_string(const Resolution &resolution)
+{
+    switch (resolution)
+    {
+        case Resolution::NATIVE:
+            return "native";
+        case Resolution::HD1080P:
+            return "1080p";
+        case Resolution::HD720P:
+            return "720p";
+        default:
+            util::log_error("Unrecognized resolution type when trying to convert to string.");
+            assert(false);
+            return "UNKNOWN";
+    }
+}
+
+bool is_valid_resolution(const std::string &resolution)
+{
+    if (resolution == "native")
+    {
+        return true;
+    }
+    else if (resolution == "1080p")
+    {
+        return true;
+    }
+    else if (resolution == "720p")
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+Resolution resolution_string_to_enum(const std::string &resolution)
+{
+    if (resolution == "native")
+    {
+        return Resolution::NATIVE;
+    }
+    else if (resolution == "1080p")
+    {
+        return Resolution::HD1080P;
+    }
+    else if (resolution == "720p")
+    {
+        return Resolution::HD720P;
+    }
+    else
+    {
+        throw std::invalid_argument("Invalid resolution string.");
+    }
+}
+
+std::tuple<int, int> get_height_and_width(const Resolution &resolution)
+{
+    switch (resolution)
+    {
+        case Resolution::NATIVE:
+            return {DEFAULT_HEIGHT, DEFAULT_WIDTH};
+        case Resolution::HD1080P:
+            return {1080, 1920};
+        case Resolution::HD720P:
+            return {720, 1280};
+        default:
+            util::log_error("Invalid resolution when trying to get height and width.");
+            assert(false);
+            return {DEFAULT_HEIGHT, DEFAULT_WIDTH};
+    }
+}
+
+} // namespace rtsp

--- a/azureeyemodule/app/streaming/resolution.hpp
+++ b/azureeyemodule/app/streaming/resolution.hpp
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+// Standard library includes
+#include <string>
+#include <tuple>
+
+namespace rtsp {
+
+/** Default height of the RTSP images. */
+const int DEFAULT_HEIGHT = 616;
+
+/** Default width of the RTSP images. */
+const int DEFAULT_WIDTH = 816;
+
+/** The different resolutions we can use. */
+enum class Resolution {
+   NATIVE,
+   HD1080P,
+   HD720P,
+};
+
+/** Returns true if the given resolution string is valid. False if not. */
+bool is_valid_resolution(const std::string &resolution);
+
+/** Returns the Resolution enum variant from the given string. Throws an invalid_argument exception if resolution string is not valid. */
+Resolution resolution_string_to_enum(const std::string &resolution);
+
+/** Returns a string representation of the Resolution enum variant. */
+std::string resolution_to_string(const Resolution &resolution);
+
+/** Returns the height and width of the frames at the given resolution. */
+std::tuple<int, int> get_height_and_width(const Resolution &resolution);
+
+} // namespace rtsp

--- a/azureeyemodule/app/streaming/rtsp.hpp
+++ b/azureeyemodule/app/streaming/rtsp.hpp
@@ -2,6 +2,9 @@
 // Licensed under the MIT license.
 #pragma once
 
+// Local includes
+#include "resolution.hpp"
+
 // Standard library includes
 #include <string>
 #include <vector>
@@ -29,35 +32,34 @@ typedef struct {
 } H264;
 
 /** Returns the current resolution of all the streams of the given type. */
-std::string get_resolution(const StreamType &type);
+Resolution get_resolution(const StreamType &type);
 
 /** Main loop for the RTSP server thread. */
 void* gst_rtsp_server_thread(void *unused);
 
-/** Returns true if the given resolution string is valid. False if not. */
-bool is_valid_resolution(const std::string &resolution);
-
 /**
- * Set the given stream's parameters. Resolution should be a string of "native", "1080p" or "720p".
+ * Set the given stream's parameters.
  *
  * Note that setting the resolution here is NECESSARY, but not SUFFICIENT. You must also restart
  * the model pipeline with iot::restart_model_with_new_resolution().
  */
 void set_stream_params(const StreamType &type, bool enable);
 void set_stream_params(const StreamType &type, int fps);
-void set_stream_params(const StreamType &type, const std::string &resolution);
+void set_stream_params(const StreamType &type, const Resolution &resolution);
 void set_stream_params(const StreamType &type, int fps, bool enable);
-void set_stream_params(const StreamType &type, const std::string &resolution, bool enable);
-void set_stream_params(const StreamType &type, const std::string &resolution, int fps, bool enable);
+void set_stream_params(const StreamType &type, const Resolution &resolution, bool enable);
+void set_stream_params(const StreamType &type, const Resolution &resolution, int fps, bool enable);
 
 /** This function would write the current frame to a specific location*/
 void take_snapshot(const StreamType &type);
 
 /** Update the RGB frame that we display in the raw RTSP stream. */
 void update_data_raw(const cv::Mat &mat);
+void update_data_raw(const std::vector<cv::Mat> &mats);
 
 /** Update the RGB frame that we display in the result RTSP stream. */
 void update_data_result(const cv::Mat &mat);
+void update_data_result(const std::vector<cv::Mat> &mats);
 
 /** Update the H.264 data that we display in the Raw H.264 stream. */
 void update_data_h264(const H264 &frame);

--- a/azureeyemodule/app/util/helper.hpp
+++ b/azureeyemodule/app/util/helper.hpp
@@ -62,6 +62,9 @@ int run_command(std::string command);
 /** Search for the given word in the given file. */
 bool search_keyword_in_file(std::string keyword, std::string filename);
 
+/** Return a timestamp as an easy to read string. */
+std::string timestamp_to_string(int64_t ts);
+
 /** Print the version. */
 void version();
 

--- a/azureeyemodule/app/util/time_aligned_buffer.cpp
+++ b/azureeyemodule/app/util/time_aligned_buffer.cpp
@@ -1,0 +1,150 @@
+// Standard library includes
+#include <vector>
+
+// Local includes
+#include "time_aligned_buffer.hpp"
+
+namespace timebuf {
+
+
+TimeAlignedBuffer::TimeAlignedBuffer(const cv::Mat &default_item)
+    : n_timestamped_frames(10), default_value(default_item)
+{
+    // Nothing to do
+}
+
+void TimeAlignedBuffer::put(const timestamped_frame_t &frame_and_ts)
+{
+    // Add the item
+    if (this->index >= this->timestamped_frames.size())
+    {
+        // Add a new slot
+        this->timestamped_frames.push_back(frame_and_ts);
+    }
+    else
+    {
+        // Overwrite an old item's slot
+        this->timestamped_frames.at(this->index) = frame_and_ts;
+    }
+
+    this->index += 1;
+    if (this->index >= this->n_timestamped_frames)
+    {
+        this->index = 0;
+    }
+}
+
+size_t TimeAlignedBuffer::size() const
+{
+    return this->timestamped_frames.size();
+}
+
+std::vector<cv::Mat> TimeAlignedBuffer::get_best_match_and_older(int64_t timestamp)
+{
+    // If there is nothing in the buffer yet, let's return a default value.
+    if (this->timestamped_frames.size() == 0)
+    {
+        #ifdef DEBUG_TIME_ALIGNMENT
+            util::log_debug("New Inference: No frames in buffer. Sending cached frame.");
+        #endif
+        return this->default_value;
+    }
+
+    cv::Mat oldest_frame;
+    int64_t oldest_ts = LLONG_MAX;
+
+    int64_t best_match_ts = 0;
+    int64_t smallest_time_difference = LLONG_MAX;
+
+    // Sanity check
+    assert(this->timestamped_frames.size() != 0);
+
+    // Search through the circular buffer for the oldest timestamp and the best matching timestamp.
+    for (const auto &tup : this->timestamped_frames)
+    {
+        auto tup_ts = std::get<1>(tup);
+        if (tup_ts < oldest_ts)
+        {
+            std::tie(oldest_frame, oldest_ts) = tup;
+        }
+
+        // Also find the best match
+        auto timedelta = (tup_ts > timestamp) ? (tup_ts - timestamp) : (timestamp - tup_ts);
+        if (timedelta < smallest_time_difference)
+        {
+           best_match_ts = std::get<1>(tup);
+           smallest_time_difference = timedelta;
+        }
+    }
+
+    // Sanity check
+    assert(oldest_ts != LLONG_MAX);
+    assert(best_match_ts != 0);
+    assert(smallest_time_difference != LLONG_MAX);
+    #ifdef DEBUG_TIME_ALIGNMENT
+        util::log_debug("New Inference: Matched " + util::timestamp_to_string(timestamp) + " with " + util::timestamp_to_string(best_match_ts));
+    #endif
+
+    if (oldest_ts > timestamp)
+    {
+        #ifdef DEBUG_TIME_ALIGNMENT
+            util::log_debug("New Inference: oldest frame is not old enough! We will store " + std::to_string(this->n_timestamped_frames * 2) + " frames now.");
+        #endif
+
+        // If oldest frame occurs after this
+        // frame's timestamp, we are overwriting our buffer frames before the network can inference even a single time.
+        // Therefore the buffer is not large enough and needs to be resized.
+        this->n_timestamped_frames *= 2;
+
+        // Use this frame as the best one, but don't remove it, since it doesn't really match.
+        assert(best_match_ts == oldest_ts);
+        return std::vector<cv::Mat>{oldest_frame};
+    }
+    else
+    {
+        // If the oldest frame occurs before this inference, then the frame we are inferencing on
+        // is somewhere in our buffer. Search through to find it and all older frames.
+        std::vector<cv::Mat> best_and_older;
+        std::vector<size_t> indices_to_erase;
+        for (size_t i = 0; i < this->timestamped_frames.size(); i++)
+        {
+            const auto &tup = this->timestamped_frames.at(i);
+            if (std::get<1>(tup) <= best_match_ts)
+            {
+                indices_to_erase.push_back(i);
+                best_and_older.push_back(std::get<0>(tup));
+            }
+        }
+
+        // Update the default value
+        this->default_value = best_and_older.back();
+
+        // Remove all the old frames.
+        assert(best_and_older.size() > 0);
+        assert(indices_to_erase.size() > 0);
+        auto start = indices_to_erase.at(0);
+        auto end = indices_to_erase.back() + 1;
+        this->timestamped_frames.erase(this->timestamped_frames.begin() + start, this->timestamped_frames.begin() + end);
+
+        // We need to decrement index by an amount equal
+        // to the number of indices we removed that are less than it.
+        size_t amount = 0;
+        for (auto i : indices_to_erase)
+        {
+            if (i < this->index)
+            {
+                amount++;
+            }
+        }
+        assert(amount <= this->index);
+        this->index -= amount;
+
+        #ifdef DEBUG_TIME_ALIGNMENT
+            util::log_debug("New Inference: Found " + std::to_string(best_and_older.size()) + " frames. Now have " + std::to_string(this->size()) + " frames left.");
+        #endif
+
+        return best_and_older;
+    }
+}
+
+} // namespace timebuf

--- a/azureeyemodule/app/util/time_aligned_buffer.hpp
+++ b/azureeyemodule/app/util/time_aligned_buffer.hpp
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * This module represents a framebuffer that can be used for storing timestamped frames.
+ * We use this for time-aligning frames with neural network inferences.
+ */
+#pragma once
+
+// Standard library includes
+#include <string>
+#include <tuple>
+#include <vector>
+
+// Third party includes
+#include <opencv2/gapi/mx.hpp>
+
+// Local includes
+#include "helper.hpp"
+
+namespace timebuf {
+
+/** A tuple of cv::Mat and timestamp for that frame. */
+using timestamped_frame_t = std::tuple<cv::Mat, int64_t>;
+
+class TimeAlignedBuffer
+{
+public:
+    /** Constructor. Takes a default value to return until we get frames in the buffer. */
+    TimeAlignedBuffer(const cv::Mat &default_item);
+
+    /** Copies the given frame and timestamp into the buffer, overwriting an old one if the we end up wrapping. */
+    void put(const timestamped_frame_t &frame_and_ts);
+
+    /** Removes the best matching frame and all older ones and returns them as a vector. If no frames in buffer, we return the default one or the last one we returned. */
+    std::vector<cv::Mat> get_best_match_and_older(int64_t timestamp);
+
+    /** Returns the current number of items in the buffer. */
+    size_t size() const;
+
+private:
+    /** The index to write something to. */
+    size_t index = 0;
+
+    /** Number of timestamped frames that we can currently have in the buffer. Increases if we need more capacity. */
+    size_t n_timestamped_frames;
+
+    /** The frame we return if there are no frames to return. */
+    cv::Mat default_value;
+
+    /** Circular buffer of frames with their timestamps. */
+    std::vector<timestamped_frame_t> timestamped_frames;
+};
+
+} // namespace timebuf


### PR DESCRIPTION
This commit adds a new feature that can be enabled in the module twin
via "TimeAlignRTSP": "true".

This feature aligns the frames in the result RTSP stream with the
results from the neural network.

When this feature is turned OFF (the default), we send out frames as
soon as we get them in the raw and result channel. Therefore they look
identical when viewed, except for the mark-ups. The mark-ups (like
bounding boxes) meanwhile are derived from the neural network, but much
less frequently, especially for high-latency networks like OpenPose,
OCR, or Faster-RCNN-ResNet50. When using a high-latency network
therefore, you can see that the mark-ups are applied to the wrong frame.
This is due to applying the mark-ups to whatever frame we have when we
get a new inference from the network. But because the network is slow,
the frame that we have on hand is not the frame used by the network.

This has the advantage of being memory efficient and fast. We do not
store anything but the last frame from the camera and the last inference
from the network, and we send them all out as often as we get them.

But it has the disadvantage of being noticeably out of step with reality
when the network has high latency, such as when viewing OpenPose results
and the skeleton seems to walk behind the person it is detecting.

When this feature is turned ON, we still send out the raw frames as
often as we get them, but we hold back a copy of each raw frame until we
get a new neural network inference. As soon as we get a new inference,
we go through the buffer of frames we are holding back and find the
frame that best corresponds in time with the inference, then we apply
the inference mark-ups to that frame and all older ones. Then we send
those marked-up frames all in one big batch to the RTSP server.

This has the advantage of being as best time-aligned as possible,
so that the mark-ups are as aligned as we can get them with the video.
However, for networks with a LOT of latency, like OCR, we end up storing
so many frames that we can't send all of them to the RTSP server without
overwriting old frames (and therefore causing the video to jump). So to
combat this, I've made it so that when we have too many frames to send
to the RTSP server, we only send every Nth frame. However, this may lead
to an interesting situation where the mark-ups actually jump ahead of
the video and wait for the video to catch up.

The disadvantage of this feature is that 1) when it is turned on, we
need a lot of memory to hold all the frames, and 2) the video is held
back by an amount of time equal to about the average latency of the
neural network. This is clearly visible when viewing the raw and result
frames side-by-side.