### PR TITLE
Fix Cannot Find Libffi

### DIFF
--- a/machine-learning-notebooks/train-from-scratch/Dockerfile
+++ b/machine-learning-notebooks/train-from-scratch/Dockerfile
@@ -1,7 +1,8 @@
 # cf. https://github.com/Azure/AzureML-Containers
 FROM mcr.microsoft.com/azureml/intelmpi2018.3-cuda10.0-cudnn7-ubuntu16.04
 
-RUN echo "Hello from custom container!"
-
 # opencv-python dependency
 RUN apt-get install -y libgl1-mesa-dev
+
+# Fix for AML not finding the right libffi version
+RUN ln -s /opt/miniconda/lib/libffi.so.7 /usr/lib/x86_64-linux-gnu/libffi.so.7


### PR DESCRIPTION
This commit fixes a bug where newer versions of AML (or maybe Conda?)
cannot find the right version of libffi in the Banana tutorial notebook.

See issue
https://github.com/microsoft/azure-percept-advanced-development/issues/48.