### PR TITLE
Use Azure ML Dataset for training instead of Datastore

### DIFF
--- a/machine-learning-notebooks/transfer-learning-custom-azureml/3.Train_with_AzureML.ipynb
+++ b/machine-learning-notebooks/transfer-learning-custom-azureml/3.Train_with_AzureML.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8c0595d5",
+   "id": "8be5dada",
    "metadata": {},
    "source": [
     "Copyright (c) Microsoft Corporation.<br>\n",
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2309e4aa",
+   "id": "ac2ffa37",
    "metadata": {},
    "source": [
     "## Imports"
@@ -35,7 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69f13f5a",
+   "id": "af4d260f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74a4e5b7",
+   "id": "e298ff7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Additional install needed to use the Dataset object\n",
+    "import sys\n",
+    "! {sys.executable} -m pip install azureml-dataset-runtime==1.30.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "277a5e2f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b89a2b24",
+   "id": "177bfd96",
    "metadata": {},
    "source": [
     "## Connect to the Azure ML Workspace\n",
@@ -96,7 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "228fc75e",
+   "id": "f9c5af96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +117,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14157cbb",
+   "id": "19517ab3",
+   "metadata": {},
+   "source": [
+    "## Create Azure ML Dataset object\n",
+    "\n",
+    "Use cloud default Datastore to create a cloud Azure ML Dataset to later use in training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a910514",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datastore = ws.get_default_datastore()\n",
+    "dataset = Dataset.File.from_files(path=(datastore, 'office_supplies'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3c52589",
    "metadata": {},
    "source": [
     "## Create project directory (continue on here _after_ you have labeled data)\n",
@@ -116,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d1719c4",
+   "id": "327ce5f8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +161,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8d0ff95",
+   "id": "c721a9ba",
    "metadata": {},
    "source": [
     "Download your COCO formated annotations from the Azure ML Studio labeling project and drag-and-drop them into this new `project_files` folder."
@@ -136,7 +169,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63b8c556",
+   "id": "bffc0c05",
    "metadata": {},
    "source": [
     "## Create and/or reuse a GPU cluster for training\n",
@@ -147,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0f65b97",
+   "id": "416fa696",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ba0b7d1",
+   "id": "6955ad26",
    "metadata": {},
    "source": [
     "## Define an environment\n",
@@ -181,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efb29c1e",
+   "id": "150d3848",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27839980",
+   "id": "68a19b9a",
    "metadata": {},
    "source": [
     "## Labels\n",
@@ -211,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ee9ce55",
+   "id": "34a0306d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21c18cfd",
+   "id": "bfdc884f",
    "metadata": {},
    "source": [
     "## Scripts to format data and train model\n",
@@ -247,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f5634aa",
+   "id": "972db49c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7ebe4888",
+   "id": "a8cf47b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d645c3b",
+   "id": "779df98e",
    "metadata": {},
    "source": [
     "Prepare model config variables, hyperparameters and file paths for a tensorflow configuration file for SSDLite-Mobilenetv2 model training.\n",
@@ -459,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42a67b12",
+   "id": "cb041542",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -655,7 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2aa6c491",
+   "id": "11c9a031",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,7 +713,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a77cb570",
+   "id": "c391d4ad",
    "metadata": {},
    "source": [
     "**Train script**\n",
@@ -691,7 +724,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "074fbd53",
+   "id": "e4e00ebe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -745,14 +778,6 @@
     "    \n",
     "    args = parser.parse_args()\n",
     "    return args\n",
-    "\n",
-    "def get_data(datastore_path):\n",
-    "    \"\"\"Get the data from the default datastore of the workspace\n",
-    "    and return the data folder where it is located on compute\"\"\"\n",
-    "    data_folder = os.sep + \\\n",
-    "                  os.sep.join(os.getcwd().split(os.sep)[:-2]) + \\\n",
-    "                  os.sep + datastore_path\n",
-    "    return data_folder\n",
     "\n",
     "def prep_data(annot_file, data_folder):\n",
     "    \"\"\"Convert coco data format to TFRecord (with image files in the\n",
@@ -910,7 +935,7 @@
     "model_path_prefix = './outputs/model.ckpt-{}'.format(args.num_epochs)\n",
     "\n",
     "# Download data\n",
-    "data_folder = get_data(args.datastore_path)\n",
+    "data_folder = args.datastore_path\n",
     "# Convert annotations and data to TFRecord format\n",
     "prep_data(args.annot_file, data_folder)\n",
     "# Decompress model from archive file\n",
@@ -927,7 +952,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c245e970",
+   "id": "300caac4",
    "metadata": {},
    "source": [
     "## Run experiment\n",
@@ -945,12 +970,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5278429c",
+   "id": "025becb5",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Training script args - take a look at training script to see how they are used\n",
-    "script_args = ['--ds-path', 'office_supplies', # may wish to change this name\n",
+    "script_args = ['--ds-path', dataset.as_named_input('office_supplies').as_mount(),\n",
     "               '--annot-file', '<add-your-coco-annot-filename-here.json>',\n",
     "               '--num-epochs', num_epochs,\n",
     "               '--num-classes', num_classes]\n",
@@ -970,7 +995,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ab731c7",
+   "id": "5fa58d6a",
    "metadata": {},
    "source": [
     "Now, go to the Azure Portal and Azure ML Studio to check on the progress of the Run.  You may move on in the notebook once the Run has finished.\n",
@@ -980,7 +1005,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "078d15db",
+   "id": "005941ed",
    "metadata": {},
    "source": [
     "## Register and download model\n",
@@ -989,13 +1014,15 @@
     "\n",
     "Here, we want to register the model based on the experiment and run above, so that we can download the files.  We register the entire `outputs` directory from Azure ML Compute so that we can access multiple files as our model checkpoint consists of several files (registering an entire directory is an option when you register models with Azure ML).\n",
     "\n",
-    "We also download the model files and anything in the `outputs` folder from the compute to the `experiment_outputs` directory, a new directory for the outputs of the Azure ML experiment locally."
+    "We also download the model files and anything in the `outputs` folder from the compute to the `experiment_outputs` directory, a new directory for the outputs of the Azure ML experiment locally.\n",
+    "\n",
+    "If using the `run_dict.id` does not work, get the Run ID from the Experiment Run in the Azure ML Studio and enter below in the `a specific run id` placeholder and uncomment the line."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8bdb9970",
+   "id": "7df72ffe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1017,7 +1044,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa028ecf",
+   "id": "478c3e16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1032,7 +1059,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8833296e",
+   "id": "d397fa15",
    "metadata": {},
    "source": [
     "Now, let's download the model files locally (may take some time).  They will appear in a folder called `experiment_outputs` along with the TFRecord dataset files."
@@ -1041,7 +1068,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e638e8a8",
+   "id": "2209d0a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1053,7 +1080,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e4e68bf",
+   "id": "22113281",
    "metadata": {},
    "source": [
     "## Next steps\n",
@@ -1064,7 +1091,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7670e1f3",
+   "id": "da43bf9b",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Changes to training notebook to update for better usage of the data in more Azure ML way:
- Create a Dataset object from the default Datastore
- Update training script to use the Dataset object
- Update the submit run step to use Dataset location/path