### PR TITLE
Fix H.264 streaming bug

### DIFF
--- a/azureeyemodule/README.md
+++ b/azureeyemodule/README.md
@@ -141,6 +141,7 @@ These are the allowed values for this IoT Module's twin:
 * `RawStream`: Boolean. Enables/disables streaming the raw camera feed.
 * `ResultStream`: Boolean. Enables/disables streaming the result feed, which will be the raw camera feed plus
   any markups done by the neural network post-processing.
+* `H264Stream`: Boolean. Enables/disables the H.264-encoded raw camera feed.
 * `StreamFPS`: Integer. The desired frames per second of the camera feed.
 * `StreamResolution`: String. Must be one of `native`, `1080p`, or `720p`. Sets the resolution of the camera feed.
 * `TelemetryIntervalNeuralNetworkMs`: Integer. Determines how often to send messages from the neural network. Sends a message at most once every this

--- a/azureeyemodule/app/CMakeLists.txt
+++ b/azureeyemodule/app/CMakeLists.txt
@@ -29,6 +29,7 @@ find_library(ORT_LIB onnxruntime)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GSTREAMER gstreamer-1.0>=1.14 REQUIRED)
 pkg_check_modules(RTSP gstreamer-rtsp-server-1.0 REQUIRED)
+pkg_check_modules(GSTREAMER_APP gstreamer-app-1.0>=1.14 REQUIRED)
 
 # Add USE_EDGE_MODULES flags to the C and CXX flags for the compiler
 # (This is for Azure IoT C SDK)
@@ -94,6 +95,7 @@ target_link_libraries(${APP_NAME}
     ${OpenCV_LIBS}
     ${RTSP_LIBRARIES}
     ${GSTREAMER_LIBRARIES}
+    ${GSTREAMER_APP_LIBRARIES}
     ${ORT_LIB}
     gobject-2.0
     glib-2.0

--- a/azureeyemodule/app/imgcapture/dataloop.cpp
+++ b/azureeyemodule/app/imgcapture/dataloop.cpp
@@ -3,6 +3,7 @@
 
 // Standard library includes
 #include <dirent.h>
+#include <errno.h>
 #include <string>
 #include <thread>
 
@@ -57,7 +58,7 @@ static void upload_snapshot_directory(const secure::SecureAIParams &security_par
     d_data = opendir(snapshot_dpath.c_str());
     if (d_data == NULL)
     {
-        util::log_error("Could not open snapshot directory for retrain loop data upload.");
+        util::log_error("Could not open snapshot directory for retrain loop data upload. Errno: " + std::to_string(errno));
         return;
     }
 

--- a/azureeyemodule/app/iot/iot_update.cpp
+++ b/azureeyemodule/app/iot/iot_update.cpp
@@ -294,6 +294,15 @@ static void parse_streams(JSON_Object *root_object)
         rtsp::set_stream_params(rtsp::StreamType::RESULT, (bool)json_object_dotget_boolean(root_object, "ResultStream"));
     }
 
+    if (json_object_dotget_value(root_object, "desired.H264Stream") != nullptr)
+    {
+        rtsp::set_stream_params(rtsp::StreamType::H264_RAW, (bool)json_object_dotget_boolean(root_object, "desired.H264Stream"));
+    }
+    if (json_object_dotget_value(root_object, "H264Stream") != nullptr)
+    {
+        rtsp::set_stream_params(rtsp::StreamType::H264_RAW, (bool)json_object_dotget_boolean(root_object, "H264Stream"));
+    }
+
     if (json_object_dotget_value(root_object, "desired.StreamFPS") != nullptr)
     {
         auto fps = json_object_dotget_number(root_object, "desired.StreamFPS");


### PR DESCRIPTION
This commit fixes the bug where the H.264 stream will crash after X
minutes of streaming it.

This changes from a pull-style mechanism, where the GStreamer pipeline
fires a callback function every time it needs a new buffer, which then
grabs a buffer from a non-thread-safe queue, to a push-style mechanism,
where the GStreamer pipeline is split into two pieces: an appsrc which
is constantly accepting buffers from the main thread, and another half
which is only connected when a client has connected to the device.

I also added a new "H264Stream" parameter to the module twin, which
allows you to turn off the stream. Previously it turns out you had no
way of turning off the H.264 stream.