### PR TITLE
Fix disconnecting H.264 stream multiple times

### DIFF
--- a/azureeyemodule/app/model/objectdetector.cpp
+++ b/azureeyemodule/app/model/objectdetector.cpp
@@ -126,7 +126,7 @@ bool ObjectDetector::pull_data_uvc_video(cv::GStreamingCompiled &pipeline)
     {
         //Generic UVC camera doesn't provide H264 stream so we don't handle h264 output here
         this->handle_inference_output(out_ts, out_seqno, out_boxes, out_labels, out_confidences, out_size, last_boxes, last_labels, last_confidences);
-        //Intel doesn't provide frame timestamp for UVC camera input so we use the timestamp of inference results object here, 
+        //Intel doesn't provide frame timestamp for UVC camera input so we use the timestamp of inference results object here,
         //which is identical to the frame timestamp
         this->handle_bgr_output(out_bgr, out_ts, last_bgr, last_boxes, last_labels, last_confidences);
 


### PR DESCRIPTION
This commit fixes an issue where we are accidentally disconnecting the
H.264 stream twice as soon as clients disconnect. This bug doesn't
really cause any problems, but it does cause us to print something about
disconnecting twice to the log, when we are only supposed to be
disconnecting once.

Also added some sanity checks on timestamps and reverted the accidental
change to the way we alocated memory for the raw stream's frames.

Finally, added a unique appsrc identifier to each appsrc. This is necessary for the H264 disconnecting fix mentioned above, but is also a nice-to-have in case we want to reference a specific appsrc.